### PR TITLE
Colors as constants

### DIFF
--- a/tests/test_color/test_constants/test_rgb.py
+++ b/tests/test_color/test_constants/test_rgb.py
@@ -1,0 +1,13 @@
+"""Tests for color constants."""
+
+import numpy as np
+
+from tueplots.color.constants import rgb
+
+
+def test_tue_dark():
+    assert isinstance(rgb.tue_dark, np.ndarray)
+
+
+def test_tue_gray():
+    assert isinstance(rgb.tue_gray, np.ndarray)

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,6 +1,0 @@
-from tueplots import colors
-
-
-def test_tue_dark():
-    color = colors.tue_dark()
-    assert isinstance(color, tuple)

--- a/tueplots/axes.py
+++ b/tueplots/axes.py
@@ -5,7 +5,6 @@ def lines(
     *,
     base_width=1.0,
     color="black",
-    facecolor="none",
     spines_left=True,
     spines_right=True,
     spines_top=True,

--- a/tueplots/color/constants/rgb.py
+++ b/tueplots/color/constants/rgb.py
@@ -1,0 +1,9 @@
+"""RGB color constants."""
+
+# _np instead of "np", because we dont want to expose numpy through
+# `rgb.np`. This is not a bulletproof solution, but "saver" options
+# would require a lot more import logic and that feels a bit pointless.
+import numpy as _np
+
+tue_dark = _np.array([55.0 / 255.0, 65.0 / 255.0, 74.0 / 255.0])
+tue_gray = _np.array([175.0 / 255.0, 179.0 / 255.0, 183.0 / 255.0])

--- a/tueplots/colors.py
+++ b/tueplots/colors.py
@@ -1,9 +1,0 @@
-"""Some default colors."""
-
-
-def tue_dark():
-    return 55.0 / 255.0, 65.0 / 255.0, 74.0 / 255.0
-
-
-def tue_gray():
-    return 175.0 / 255.0, 179.0 / 255.0, 183.0 / 255.0

--- a/tueplots/figsize.py
+++ b/tueplots/figsize.py
@@ -1,3 +1,5 @@
+"""Figure size settings."""
+
 # Double-column formats
 
 

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -1,5 +1,4 @@
 """Font settings for conference papers and journals."""
-from . import colors
 
 
 def neurips(*, usetex=False, family="serif"):


### PR DESCRIPTION
Self-defined colors are now constants in the module `tueplots.color.constants.rgb`. For Hex-colors, we can create `constants.hex` or something like this. 