### PR TITLE
larger timeout

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,4 @@ deps =
     byexample
     matplotlib
 commands =
-    byexample -l python --timeout 5 README.md
+    byexample -l python --timeout 20 README.md


### PR DESCRIPTION
`byexample` seems to have a very low timeout threshold. This PR increases it a bit, to be on the safe side of things. If this keeps breaking, there is something to look into...