### PR TITLE
changed to solid gridlines as default, added option to set axis_below

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ consider the `axes.lines()` setting.
 ```python
 >>> from tueplots import axes
 >>> axes.lines()
-{'axes.edgecolor': 'black',
+{'axes.axisbelow': True,
+ 'axes.edgecolor': 'black',
  'axes.labelcolor': 'black',
  'axes.linewidth': 0.5,
  'axes.spines.bottom': True,
@@ -199,7 +200,7 @@ consider the `axes.lines()` setting.
  'axes.spines.top': True,
  'grid.alpha': 0.25,
  'grid.color': 'black',
- 'grid.linestyle': 'dotted',
+ 'grid.linestyle': 'solid',
  'grid.linewidth': 0.5,
  'legend.edgecolor': 'inherit',
  'lines.linewidth': 0.5,
@@ -218,7 +219,8 @@ consider the `axes.lines()` setting.
  'ytick.minor.size': 1.75,
  'ytick.minor.width': 0.25}
 >>> axes.lines(base_width=0.5, color="black", spines_right=False, spines_top=False)
-{'axes.edgecolor': 'black',
+{'axes.axisbelow': True,
+ 'axes.edgecolor': 'black',
  'axes.labelcolor': 'black',
  'axes.linewidth': 0.5,
  'axes.spines.bottom': True,
@@ -227,7 +229,7 @@ consider the `axes.lines()` setting.
  'axes.spines.top': False,
  'grid.alpha': 0.25,
  'grid.color': 'black',
- 'grid.linestyle': 'dotted',
+ 'grid.linestyle': 'solid',
  'grid.linewidth': 0.5,
  'legend.edgecolor': 'inherit',
  'lines.linewidth': 0.5,

--- a/tueplots/axes.py
+++ b/tueplots/axes.py
@@ -11,6 +11,7 @@ def lines(
     spines_bottom=True,
     xtick_direction="inout",
     ytick_direction="inout",
+    axis_below=True,
 ):
     return {
         # Set the line-widths appropriately (including the grid)
@@ -36,9 +37,10 @@ def lines(
         "grid.color": color,
         # Update the linestyle of the grid
         # (it shares a color with the frame, and needs to be distinguishable)
-        "grid.linestyle": "dotted",
+        "grid.linestyle": "solid",
         "grid.alpha": 0.25,
         # Set visibility of spines
+        "axes.axisbelow": axis_below,
         "axes.spines.left": spines_left,
         "axes.spines.right": spines_right,
         "axes.spines.top": spines_top,


### PR DESCRIPTION
Personally, I'm not a fan of a dotted grid (it seems too busy to me). So I'm making a request to return to 

`"grid.linestyle": "solid",` :)

I also added an optional argument in `axes.lines` to set `axis_below=True,` which sets the grid lines below the plotted content (i.e. with a lower z coordinate). This seems much nicer to me in general, but in particular for bar charts and histograms.