### PR TITLE
Ph color

### DIFF
--- a/tueplots/constants/color/rgb.py
+++ b/tueplots/constants/color/rgb.py
@@ -38,9 +38,9 @@ pn_orange = _np.array([255, 153, 51]) / 255.0
 pn_gray = tue_gray
 pn_red = tue_red
 
-# the Corporate-ID colors of the Max Planck Society, 
+# the Corporate-ID colors of the Max Planck Society,
 # provided as a curtesy to our colleagues at the MPI IS
 mpg_green = _np.array([17, 102, 86]) / 255.0
-mpg_lightgreen = mpg_green + 0.5 * (255.0 - mpg_green) # 50% version
+mpg_lightgreen = mpg_green + 0.5 * (255.0 - mpg_green)  # 50% version
 mpg_gray = _np.array([221, 222, 214]) / 255.0
-mpg_lightgray = mpg_gray + 0.5 * (255.0 - mpg_gray) # 50% version
+mpg_lightgray = mpg_gray + 0.5 * (255.0 - mpg_gray)  # 50% version

--- a/tueplots/constants/color/rgb.py
+++ b/tueplots/constants/color/rgb.py
@@ -38,8 +38,7 @@ pn_orange = _np.array([255, 153, 51]) / 255.0
 pn_gray = tue_gray
 pn_red = tue_red
 
-# the Corporate-ID colors of the Max Planck Society,
-# provided as a curtesy to our colleagues at the MPI IS
+# the Corporate-ID colors of the Max Planck Society:
 mpg_green = _np.array([17, 102, 86]) / 255.0
 mpg_lightgreen = mpg_green + 0.5 * (255.0 - mpg_green)  # 50% version
 mpg_gray = _np.array([221, 222, 214]) / 255.0

--- a/tueplots/constants/color/rgb.py
+++ b/tueplots/constants/color/rgb.py
@@ -37,3 +37,10 @@ pn_blue = _np.array([41, 68, 165]) / 255.0
 pn_orange = _np.array([255, 153, 51]) / 255.0
 pn_gray = tue_gray
 pn_red = tue_red
+
+# the Corporate-ID colors of the Max Planck Society, 
+# provided as a curtesy to our colleagues at the MPI IS
+mpg_green = _np.array([17, 102, 86]) / 255.0
+mpg_lightgreen = mpg_green + 0.5 * (255.0 - mpg_green) # 50% version
+mpg_gray = _np.array([221, 222, 214]) / 255.0
+mpg_lightgray = mpg_gray + 0.5 * (255.0 - mpg_gray) # 50% version


### PR DESCRIPTION
As a courtesy to our colleagues at the MPI IS, I added the two primary MPG colors `rgb.mpg_green` and `rgb.mpg_gray`, as well as two 50% versions of that color (recommended per the MPG corporate style guide).