### PR TITLE
[MOD] move requirements.txt outside of examples folder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+jupyter
+nbsphinx>=0.8.6,<0.8.7
+matplotlib


### PR DESCRIPTION
I figured this should be on the root level rather than the examples folder.