### PR TITLE
Notebook linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,10 @@ repos:
     rev: v5.10.1 # Make sure to use the same tag/version as specified in tox.ini.
     hooks:
       - id: isort
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.2.3
+    hooks:
+     - id: nbqa-black
+       additional_dependencies: [black==22.1.0]
+     - id: nbqa-isort
+       additional_dependencies: [isort==5.10.1]

--- a/docs/source/example_notebooks/axes.ipynb
+++ b/docs/source/example_notebooks/axes.ipynb
@@ -15,8 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tueplots import axes\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from tueplots import axes\n",
     "\n",
     "# Increase the resolution of all the plots below\n",
     "plt.rcParams.update({\"figure.dpi\": 150})"

--- a/docs/source/example_notebooks/bundles.ipynb
+++ b/docs/source/example_notebooks/bundles.ipynb
@@ -15,8 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tueplots import bundles, axes\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from tueplots import axes, bundles\n",
     "\n",
     "# Increase the resolution of all the plots below\n",
     "plt.rcParams.update({\"figure.dpi\": 150})"

--- a/docs/source/example_notebooks/color-cycles.ipynb
+++ b/docs/source/example_notebooks/color-cycles.ipynb
@@ -15,8 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
     "from tueplots import cycler\n",
     "from tueplots.constants import markers\n",
     "from tueplots.constants.color import palettes\n",

--- a/docs/source/example_notebooks/color-cycles.ipynb
+++ b/docs/source/example_notebooks/color-cycles.ipynb
@@ -45,7 +45,7 @@
    "outputs": [],
    "source": [
     "x = np.linspace(0, np.pi, 20)\n",
-    "offsets = np.linspace(0,  2*np.pi, 8, endpoint=False)\n",
+    "offsets = np.linspace(0, 2 * np.pi, 8, endpoint=False)\n",
     "yy = [np.sin(x + phi) for phi in offsets]"
    ]
   },
@@ -249,7 +249,9 @@
     }
    ],
    "source": [
-    "plt.rcParams.update(cycler.cycler(color=palettes.muted[:3], marker=markers.x_like_bold[:3]))\n",
+    "plt.rcParams.update(\n",
+    "    cycler.cycler(color=palettes.muted[:3], marker=markers.x_like_bold[:3])\n",
+    ")\n",
     "for y in yy:\n",
     "    plt.plot(x, y, linewidth=3, markersize=10)\n",
     "plt.show()"

--- a/docs/source/example_notebooks/figsizes.ipynb
+++ b/docs/source/example_notebooks/figsizes.ipynb
@@ -245,9 +245,7 @@
     }
    ],
    "source": [
-    "plt.rcParams.update(\n",
-    "    figsizes.icml2022_half(nrows=2, ncols=2, height_to_width_ratio=1.0)\n",
-    ")\n",
+    "plt.rcParams.update(figsizes.icml2022_half(nrows=2, ncols=2, height_to_width_ratio=1.0))\n",
     "\n",
     "fig, axes = plt.subplots(nrows=2, ncols=2, sharex=True, sharey=True)\n",
     "for ax in axes.flatten():\n",

--- a/docs/source/example_notebooks/figsizes.ipynb
+++ b/docs/source/example_notebooks/figsizes.ipynb
@@ -15,8 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tueplots import figsizes\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from tueplots import figsizes\n",
     "\n",
     "# Increase the resolution of all the plots below\n",
     "plt.rcParams.update({\"figure.dpi\": 150})"

--- a/docs/source/example_notebooks/fonts.ipynb
+++ b/docs/source/example_notebooks/fonts.ipynb
@@ -15,8 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tueplots import fonts, figsizes\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from tueplots import figsizes, fonts\n",
     "\n",
     "# Increase the resolution of all the plots below\n",
     "plt.rcParams.update({\"figure.dpi\": 150})\n",

--- a/docs/source/example_notebooks/fontsizes.ipynb
+++ b/docs/source/example_notebooks/fontsizes.ipynb
@@ -15,8 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tueplots import fontsizes, figsizes\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from tueplots import figsizes, fontsizes\n",
     "\n",
     "# Increase the resolution of all the plots below\n",
     "plt.rcParams.update({\"figure.dpi\": 150})\n",

--- a/docs/source/example_notebooks/markers.ipynb
+++ b/docs/source/example_notebooks/markers.ipynb
@@ -15,9 +15,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "from tueplots import markers, cycler\n",
+    "import numpy as np\n",
+    "\n",
+    "from tueplots import cycler, markers\n",
     "from tueplots.constants import markers as marker_constants\n",
     "from tueplots.constants.color import palettes\n",
     "\n",

--- a/docs/source/example_notebooks/markers.ipynb
+++ b/docs/source/example_notebooks/markers.ipynb
@@ -178,7 +178,9 @@
     }
    ],
    "source": [
-    "plt.rcParams.update(cycler.cycler(marker=marker_constants.o_sized[:5], color=palettes.pn[:5]))\n",
+    "plt.rcParams.update(\n",
+    "    cycler.cycler(marker=marker_constants.o_sized[:5], color=palettes.pn[:5])\n",
+    ")\n",
     "\n",
     "fig, ax = plt.subplots()\n",
     "for y in yy:\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ include_trailing_comma = "true"
 force_grid_wrap = "0"
 use_parentheses = "true"
 line_length = "88"
-
+profile = "black"
 
 
 # Pylint configuration

--- a/tox.ini
+++ b/tox.ini
@@ -42,10 +42,8 @@ commands =
 description = Linting (pylint)
 deps =
     pylint
-    nbqa
 ignore_errors = true
 commands =
-    nbqa pylint docs --jobs=0
     pylint tueplots --jobs=0
     pylint tests --jobs=0 --disable="missing-function-docstring"
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,12 @@ commands = pytest --verbose {posargs}
 
 [testenv:black]
 description = Code linting with Black
-deps = black
+deps =
+    black
+    nbqa
 commands =
     black --check --diff .
+    nbqa black --check --diff .
 
 [testenv:isort]
 description = Sorting imports with isort

--- a/tox.ini
+++ b/tox.ini
@@ -40,9 +40,12 @@ commands =
 
 [testenv:pylint]
 description = Linting (pylint)
-deps = pylint
+deps =
+    pylint
+    nbqa
 ignore_errors = true
 commands =
+    nbqa pylint docs --jobs=0
     pylint tueplots --jobs=0
     pylint tests --jobs=0 --disable="missing-function-docstring"
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,12 @@ commands =
 
 [testenv:isort]
 description = Sorting imports with isort
-deps = isort
+deps =
+    isort
+    nbqa
 commands =
-    isort --profile black --check --diff .
+    isort --check --diff .
+    nbqa isort --check --diff .
 
 [testenv:byexample]
 description = Run the snippets in the Readme


### PR DESCRIPTION
This PR introduces linting (black, isort) for jupyter notebooks via `nbqa` (see #80).

Introducing `nbqa pylint` would require non-trivial notebook updates, and is left to a future PR. 