### PR TITLE
Add Neurips 2022 Style

### DIFF
--- a/docs/source/getting_started/usage_example.md
+++ b/docs/source/getting_started/usage_example.md
@@ -14,7 +14,7 @@ within one module, the functions have a unified interface (wherever possible)
 (6.0, 3.7082039324993694)
 >>>
 >>> figsizes.neurips2021(nrows=3)["figure.figsize"]
-(5.499999861629998, 5.098780278910587)
+(5.5, 5.0987804071866325)
 >>>
 >>> # The full output:
 >>> figsizes.icml2022_full(nrows=4)

--- a/tests/test_rc_params_cases/case_bundles.py
+++ b/tests/test_rc_params_cases/case_bundles.py
@@ -23,6 +23,11 @@ def case_bundles_neurips2021(usetex):
     return bundles.neurips2021(usetex=usetex, nrows=2, ncols=2, family="serif")
 
 
+@pytest_cases.parametrize(usetex=[True, False])
+def case_bundles_neurips2022(usetex):
+    return bundles.neurips2022(usetex=usetex, nrows=2, ncols=2, family="serif")
+
+
 def case_bundles_jmlr2001():
     return bundles.jmlr2001(nrows=2, ncols=2, family="serif")
 

--- a/tests/test_rc_params_cases/case_figsizes.py
+++ b/tests/test_rc_params_cases/case_figsizes.py
@@ -32,6 +32,10 @@ def case_figsizes_neurips2021():
     return figsizes.neurips2021(nrows=2, ncols=3, height_to_width_ratio=1.0)
 
 
+def case_figsizes_neurips2022():
+    return figsizes.neurips2022(nrows=2, ncols=3, height_to_width_ratio=1.0)
+
+
 def case_figsizes_jmlr2001():
     return figsizes.jmlr2001(nrows=2, ncols=3, height_to_width_ratio=1.0)
 

--- a/tests/test_rc_params_cases/case_fonts.py
+++ b/tests/test_rc_params_cases/case_fonts.py
@@ -36,6 +36,22 @@ def case_fonts_neurips2021_tex_custom():
     return fonts.neurips2021_tex(family="serif")
 
 
+def case_fonts_neurips2022_default():
+    return fonts.neurips2022()
+
+
+def case_fonts_neurips2022_custom():
+    return fonts.neurips2022(family="serif")
+
+
+def case_fonts_neurips2022_tex_default():
+    return fonts.neurips2022_tex()
+
+
+def case_fonts_neurips2022_tex_custom():
+    return fonts.neurips2022_tex(family="serif")
+
+
 def case_fonts_jmlr2001_tex_default():
     return fonts.jmlr2001_tex()
 

--- a/tests/test_rc_params_cases/case_fontsizes.py
+++ b/tests/test_rc_params_cases/case_fontsizes.py
@@ -11,6 +11,10 @@ def case_fontsizes_neurips2021():
     return fontsizes.neurips2021()
 
 
+def case_fontsizes_neurips2022():
+    return fontsizes.neurips2022()
+
+
 def case_fontsizes_aistats2022():
     return fontsizes.aistats2022()
 

--- a/tueplots/bundles.py
+++ b/tueplots/bundles.py
@@ -48,6 +48,17 @@ def neurips2021(*, usetex=True, rel_width=1.0, nrows=1, ncols=1, family="sans-se
     return {**font_config, **size, **fontsize_config}
 
 
+def neurips2022(*, usetex=True, rel_width=1.0, nrows=1, ncols=1, family="sans-serif"):
+    """Neurips 2022 bundle."""
+    if usetex is True:
+        font_config = fonts.neurips2022_tex(family=family)
+    elif usetex is False:
+        font_config = fonts.neurips2022(family=family)
+    size = figsizes.neurips2022(rel_width=rel_width, nrows=nrows, ncols=ncols)
+    fontsize_config = fontsizes.neurips2022()
+    return {**font_config, **size, **fontsize_config}
+
+
 def beamer_moml(
     *,
     rel_width=1.0,

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -179,6 +179,31 @@ def neurips2021(
     )
 
 
+def neurips2022(
+    *,
+    rel_width=1.0,
+    nrows=1,
+    ncols=2,
+    constrained_layout=True,
+    tight_layout=False,
+    height_to_width_ratio=_GOLDEN_RATIO,
+):
+    """Neurips 2022 figure size."""
+
+    figsize = _from_base_in(
+        base_width_in=5.5,
+        rel_width=rel_width,
+        height_to_width_ratio=height_to_width_ratio,
+        nrows=nrows,
+        ncols=ncols,
+    )
+    return _figsize_to_output_dict(
+        figsize=figsize,
+        constrained_layout=constrained_layout,
+        tight_layout=tight_layout,
+    )
+
+
 def _from_base_pt(*, base_width_pt, **kwargs):
     base_width_in = base_width_pt / _POINTS_PER_INCH
     return _from_base_in(base_width_in=base_width_in, **kwargs)

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -154,6 +154,31 @@ def jmlr2001(
     )
 
 
+def neurips_defaults(
+    *,
+    rel_width=1.0,
+    nrows=1,
+    ncols=2,
+    constrained_layout=True,
+    tight_layout=False,
+    height_to_width_ratio=_GOLDEN_RATIO,
+):
+    """Neurips figure size defaults."""
+
+    figsize = _from_base_in(
+        base_width_in=5.5,
+        rel_width=rel_width,
+        height_to_width_ratio=height_to_width_ratio,
+        nrows=nrows,
+        ncols=ncols,
+    )
+    return _figsize_to_output_dict(
+        figsize=figsize,
+        constrained_layout=constrained_layout,
+        tight_layout=tight_layout,
+    )
+
+
 def neurips2021(
     *,
     rel_width=1.0,
@@ -164,18 +189,13 @@ def neurips2021(
     height_to_width_ratio=_GOLDEN_RATIO,
 ):
     """Neurips 2021 figure size."""
-
-    figsize = _from_base_pt(
-        base_width_pt=397.48499,
+    return neurips_defaults(
         rel_width=rel_width,
-        height_to_width_ratio=height_to_width_ratio,
         nrows=nrows,
         ncols=ncols,
-    )
-    return _figsize_to_output_dict(
-        figsize=figsize,
         constrained_layout=constrained_layout,
         tight_layout=tight_layout,
+        height_to_width_ratio=height_to_width_ratio,
     )
 
 
@@ -189,18 +209,13 @@ def neurips2022(
     height_to_width_ratio=_GOLDEN_RATIO,
 ):
     """Neurips 2022 figure size."""
-
-    figsize = _from_base_in(
-        base_width_in=5.5,
+    return neurips_defaults(
         rel_width=rel_width,
-        height_to_width_ratio=height_to_width_ratio,
         nrows=nrows,
         ncols=ncols,
-    )
-    return _figsize_to_output_dict(
-        figsize=figsize,
         constrained_layout=constrained_layout,
         tight_layout=tight_layout,
+        height_to_width_ratio=height_to_width_ratio,
     )
 
 

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -154,7 +154,47 @@ def jmlr2001(
     )
 
 
-def neurips_defaults(
+def neurips2021(
+    *,
+    rel_width=1.0,
+    nrows=1,
+    ncols=2,
+    constrained_layout=True,
+    tight_layout=False,
+    height_to_width_ratio=_GOLDEN_RATIO,
+):
+    """Neurips 2021 figure size."""
+    return _neurips_common(
+        rel_width=rel_width,
+        nrows=nrows,
+        ncols=ncols,
+        constrained_layout=constrained_layout,
+        tight_layout=tight_layout,
+        height_to_width_ratio=height_to_width_ratio,
+    )
+
+
+def neurips2022(
+    *,
+    rel_width=1.0,
+    nrows=1,
+    ncols=2,
+    constrained_layout=True,
+    tight_layout=False,
+    height_to_width_ratio=_GOLDEN_RATIO,
+):
+    """Neurips 2022 figure size."""
+    return _neurips_common(
+        rel_width=rel_width,
+        nrows=nrows,
+        ncols=ncols,
+        constrained_layout=constrained_layout,
+        tight_layout=tight_layout,
+        height_to_width_ratio=height_to_width_ratio,
+    )
+
+
+def _neurips_common(
     *,
     rel_width=1.0,
     nrows=1,
@@ -176,46 +216,6 @@ def neurips_defaults(
         figsize=figsize,
         constrained_layout=constrained_layout,
         tight_layout=tight_layout,
-    )
-
-
-def neurips2021(
-    *,
-    rel_width=1.0,
-    nrows=1,
-    ncols=2,
-    constrained_layout=True,
-    tight_layout=False,
-    height_to_width_ratio=_GOLDEN_RATIO,
-):
-    """Neurips 2021 figure size."""
-    return neurips_defaults(
-        rel_width=rel_width,
-        nrows=nrows,
-        ncols=ncols,
-        constrained_layout=constrained_layout,
-        tight_layout=tight_layout,
-        height_to_width_ratio=height_to_width_ratio,
-    )
-
-
-def neurips2022(
-    *,
-    rel_width=1.0,
-    nrows=1,
-    ncols=2,
-    constrained_layout=True,
-    tight_layout=False,
-    height_to_width_ratio=_GOLDEN_RATIO,
-):
-    """Neurips 2022 figure size."""
-    return neurips_defaults(
-        rel_width=rel_width,
-        nrows=nrows,
-        ncols=ncols,
-        constrained_layout=constrained_layout,
-        tight_layout=tight_layout,
-        height_to_width_ratio=height_to_width_ratio,
     )
 
 

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -1,7 +1,27 @@
 """Font settings for conference papers and journals."""
 
 
-def neurips_defaults(*, family="serif"):
+def neurips2021(*, family="serif"):
+    """Fonts for Neurips 2021."""
+    return _neurips_common(family=family)
+
+
+def neurips2021_tex(*, family="serif"):
+    """Fonts for Neurips 2021. LaTeX version."""
+    return _neurips_tex_common(family=family)
+
+
+def neurips2022(*, family="serif"):
+    """Fonts for Neurips 2022."""
+    return _neurips_common(family=family)
+
+
+def neurips2022_tex(*, family="serif"):
+    """Fonts for Neurips 2022. LaTeX version."""
+    return _neurips_tex_common(family=family)
+
+
+def _neurips_common(*, family="serif"):
     """Default fonts for Neurips."""
     return {
         "text.usetex": False,
@@ -14,7 +34,7 @@ def neurips_defaults(*, family="serif"):
     }
 
 
-def neurips_tex_defaults(*, family="serif"):
+def _neurips_tex_common(*, family="serif"):
     """Default fonts for Neurips. LaTeX version."""
     preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
     if family == "serif":
@@ -31,26 +51,6 @@ def neurips_tex_defaults(*, family="serif"):
         "font.family": "sans-serif",
         "text.latex.preamble": preamble,
     }
-
-
-def neurips2021(*, family="serif"):
-    """Fonts for Neurips 2021."""
-    return neurips_defaults(family=family)
-
-
-def neurips2021_tex(*, family="serif"):
-    """Fonts for Neurips 2021. LaTeX version."""
-    return neurips_tex_defaults(family=family)
-
-
-def neurips2022(*, family="serif"):
-    """Fonts for Neurips 2022."""
-    return neurips_defaults(family=family)
-
-
-def neurips2022_tex(*, family="serif"):
-    """Fonts for Neurips 2022. LaTeX version."""
-    return neurips_tex_defaults(family=family)
 
 
 def icml2022(*, family="serif"):

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -33,6 +33,38 @@ def neurips2021_tex(*, family="serif"):
     }
 
 
+def neurips2022(*, family="serif"):
+    """Fonts for Neurips 2022."""
+    return {
+        "text.usetex": False,
+        "font.serif": ["Times New Roman"],
+        "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
+        "mathtext.rm": "Times New Roman",
+        "mathtext.it": "Times New Roman:italic",
+        "mathtext.bf": "Times New Roman:bold",
+        "font.family": family,
+    }
+
+
+def neurips2022_tex(*, family="serif"):
+    """Fonts for Neurips 2022. LaTeX version."""
+    preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
+    if family == "serif":
+        return {
+            "text.usetex": True,
+            "font.family": "serif",
+            "text.latex.preamble": preamble,
+        }
+    preamble += (
+        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
+    )
+    return {
+        "text.usetex": True,
+        "font.family": "sans-serif",
+        "text.latex.preamble": preamble,
+    }
+
+
 def icml2022(*, family="serif"):
     """Fonts for ICML 2022."""
 

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -1,8 +1,8 @@
 """Font settings for conference papers and journals."""
 
 
-def neurips2021(*, family="serif"):
-    """Fonts for Neurips 2021."""
+def neurips_base(*, family="serif"):
+    """Base fonts for Neurips."""
     return {
         "text.usetex": False,
         "font.serif": ["Times New Roman"],
@@ -12,57 +12,45 @@ def neurips2021(*, family="serif"):
         "mathtext.bf": "Times New Roman:bold",
         "font.family": family,
     }
+
+
+def neurips_tex_base(*, family="serif"):
+    """Base fonts for Neurips. LaTeX version."""
+    preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
+    if family == "serif":
+        return {
+            "text.usetex": True,
+            "font.family": "serif",
+            "text.latex.preamble": preamble,
+        }
+    preamble += (
+        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
+    )
+    return {
+        "text.usetex": True,
+        "font.family": "sans-serif",
+        "text.latex.preamble": preamble,
+    }
+
+
+def neurips2021(*, family="serif"):
+    """Fonts for Neurips 2021."""
+    return neurips_base(family=family)
 
 
 def neurips2021_tex(*, family="serif"):
     """Fonts for Neurips 2021. LaTeX version."""
-    preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
-    if family == "serif":
-        return {
-            "text.usetex": True,
-            "font.family": "serif",
-            "text.latex.preamble": preamble,
-        }
-    preamble += (
-        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
-    )
-    return {
-        "text.usetex": True,
-        "font.family": "sans-serif",
-        "text.latex.preamble": preamble,
-    }
+    return neurips_tex_base(family=family)
 
 
 def neurips2022(*, family="serif"):
     """Fonts for Neurips 2022."""
-    return {
-        "text.usetex": False,
-        "font.serif": ["Times New Roman"],
-        "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
-        "mathtext.rm": "Times New Roman",
-        "mathtext.it": "Times New Roman:italic",
-        "mathtext.bf": "Times New Roman:bold",
-        "font.family": family,
-    }
+    return neurips_base(family=family)
 
 
 def neurips2022_tex(*, family="serif"):
     """Fonts for Neurips 2022. LaTeX version."""
-    preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
-    if family == "serif":
-        return {
-            "text.usetex": True,
-            "font.family": "serif",
-            "text.latex.preamble": preamble,
-        }
-    preamble += (
-        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
-    )
-    return {
-        "text.usetex": True,
-        "font.family": "sans-serif",
-        "text.latex.preamble": preamble,
-    }
+    return neurips_tex_base(family=family)
 
 
 def icml2022(*, family="serif"):

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -1,8 +1,8 @@
 """Font settings for conference papers and journals."""
 
 
-def neurips_base(*, family="serif"):
-    """Base fonts for Neurips."""
+def neurips_defaults(*, family="serif"):
+    """Default fonts for Neurips."""
     return {
         "text.usetex": False,
         "font.serif": ["Times New Roman"],
@@ -14,8 +14,8 @@ def neurips_base(*, family="serif"):
     }
 
 
-def neurips_tex_base(*, family="serif"):
-    """Base fonts for Neurips. LaTeX version."""
+def neurips_tex_defaults(*, family="serif"):
+    """Default fonts for Neurips. LaTeX version."""
     preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
     if family == "serif":
         return {
@@ -35,22 +35,22 @@ def neurips_tex_base(*, family="serif"):
 
 def neurips2021(*, family="serif"):
     """Fonts for Neurips 2021."""
-    return neurips_base(family=family)
+    return neurips_defaults(family=family)
 
 
 def neurips2021_tex(*, family="serif"):
     """Fonts for Neurips 2021. LaTeX version."""
-    return neurips_tex_base(family=family)
+    return neurips_tex_defaults(family=family)
 
 
 def neurips2022(*, family="serif"):
     """Fonts for Neurips 2022."""
-    return neurips_base(family=family)
+    return neurips_defaults(family=family)
 
 
 def neurips2022_tex(*, family="serif"):
     """Fonts for Neurips 2022. LaTeX version."""
-    return neurips_tex_base(family=family)
+    return neurips_tex_defaults(family=family)
 
 
 def icml2022(*, family="serif"):

--- a/tueplots/fontsizes.py
+++ b/tueplots/fontsizes.py
@@ -16,6 +16,11 @@ def neurips2021():
     return _from_base(base=10)
 
 
+def neurips2022():
+    """Font size for Neurips 2022."""
+    return _from_base(base=10)
+
+
 def aistats2022():
     """Font size for AISTATS 2022."""
     return _from_base(base=10)


### PR DESCRIPTION
This PR adds the Neurips 2022 style and corresponding tests (issue #88). The relevant information was extracted from section 2 of the [formatting instructions](https://media.neurips.cc/Conferences/NeurIPS2022/Styles/neurips_2022.pdf). 
