### PR TITLE
Execute CI on MacOS, Linux, and Windows as part of the workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       run: |
         pip install tox
         tox -e py3
-    - name: Run doctests in markdown files
+    - name: Run doctests for python snippets in markdown files
       run: |
         pip install tox
         tox -e doctest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,17 +46,6 @@ jobs:
       run: |
         pip install tox
         tox -e py3
-  readme-snippets:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.x"
-    - uses: actions/checkout@v2
-    - name: Run python snippets in README.md
-      run: |
-        pip install tox
-        tox -e byexample
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,11 @@ jobs:
         pip install tox
         tox -e pylint
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,11 +29,14 @@ jobs:
         pip install tox
         tox -e pylint
   tests:
-    runs-on: ${{ matrix.platform }}
+
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.8,3.9]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
     steps:
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,10 @@ jobs:
       run: |
         pip install tox
         tox -e py3
+    - name: Run doctests in markdown files
+      run: |
+        pip install tox
+        tox -e doctest
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/docs/source/getting_started/application_icml2022.md
+++ b/docs/source/getting_started/application_icml2022.md
@@ -9,119 +9,46 @@ is `plt.rcParams.update(bundles.icml2022())`:
 >>> import matplotlib.pyplot as plt
 >>> from tueplots import bundles
 >>> bundles.icml2022()
-{'axes.labelsize': 8,
- 'axes.titlesize': 8,
- 'figure.autolayout': False,
- 'figure.constrained_layout.use': True,
- 'figure.figsize': (3.25, 2.0086104634371584),
- 'font.family': 'sans-serif',
- 'font.size': 8,
- 'legend.fontsize': 6,
- 'text.latex.preamble': '\\usepackage{times} '
-                        '\\renewcommand{\\familydefault}{\\sfdefault} '
-                        '\\usepackage{sansmath} \\sansmath',
- 'text.usetex': True,
- 'xtick.labelsize': 6,
- 'ytick.labelsize': 6}
+{'text.usetex': True, 'font.family': 'sans-serif', 'text.latex.preamble': '\\usepackage{times} \\renewcommand{\\familydefault}{\\sfdefault} \\usepackage{sansmath} \\sansmath', 'figure.figsize': (3.25, 2.0086104634371584), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'font.size': 8, 'axes.labelsize': 8, 'legend.fontsize': 6, 'xtick.labelsize': 6, 'ytick.labelsize': 6, 'axes.titlesize': 8}
 >>> bundles.icml2022(family="sans-serif", usetex=False, column="full", nrows=2)
-{'axes.labelsize': 8,
- 'axes.titlesize': 8,
- 'figure.autolayout': False,
- 'figure.constrained_layout.use': True,
- 'figure.figsize': (6.75, 8.343458848123582),
- 'font.family': 'sans-serif',
- 'font.serif': ['Times'],
- 'font.size': 8,
- 'legend.fontsize': 6,
- 'mathtext.bf': 'Times:bold',
- 'mathtext.fontset': 'stix',
- 'mathtext.it': 'Times:italic',
- 'mathtext.rm': 'Times',
- 'text.usetex': False,
- 'xtick.labelsize': 6,
- 'ytick.labelsize': 6}
+{'text.usetex': False, 'font.serif': ['Times'], 'mathtext.fontset': 'stix', 'mathtext.rm': 'Times', 'mathtext.it': 'Times:italic', 'mathtext.bf': 'Times:bold', 'font.family': 'sans-serif', 'figure.figsize': (6.75, 8.343458848123582), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'font.size': 8, 'axes.labelsize': 8, 'legend.fontsize': 6, 'xtick.labelsize': 6, 'ytick.labelsize': 6, 'axes.titlesize': 8}
 >>>
 >>> # Plug any of those into either the rcParams or into an rc_context:
 >>> plt.rcParams.update(bundles.icml2022())
 >>> with plt.rc_context(bundles.icml2022()):
 ...     pass
+
 ```
 
 ## Some customisation
 
 If you don't want a pre-packaged solution, at least fix your figure- and font-sizes as follows.
+
 ```python
 >>> from tueplots import figsizes, fontsizes, fonts
 >>> figsizes.icml2022_full()
-{'figure.autolayout': False,
- 'figure.constrained_layout.use': True,
- 'figure.figsize': (6.75, 2.0858647120308955)}
+{'figure.figsize': (6.75, 2.0858647120308955), 'figure.constrained_layout.use': True, 'figure.autolayout': False}
 >>> figsizes.icml2022_half(nrows=2, constrained_layout=True, tight_layout=False)
-{'figure.autolayout': False,
- 'figure.constrained_layout.use': True,
- 'figure.figsize': (3.25, 4.017220926874317)}
+{'figure.figsize': (3.25, 4.017220926874317), 'figure.constrained_layout.use': True, 'figure.autolayout': False}
 >>> fontsizes.icml2022()
-{'axes.labelsize': 8,
- 'axes.titlesize': 8,
- 'font.size': 8,
- 'legend.fontsize': 6,
- 'xtick.labelsize': 6,
- 'ytick.labelsize': 6}
+{'font.size': 8, 'axes.labelsize': 8, 'legend.fontsize': 6, 'xtick.labelsize': 6, 'ytick.labelsize': 6, 'axes.titlesize': 8}
 >>> fonts.icml2022()
-{'font.family': 'serif',
- 'font.serif': ['Times'],
- 'mathtext.bf': 'Times:bold',
- 'mathtext.fontset': 'stix',
- 'mathtext.it': 'Times:italic',
- 'mathtext.rm': 'Times',
- 'text.usetex': False}
+{'text.usetex': False, 'font.serif': ['Times'], 'mathtext.fontset': 'stix', 'mathtext.rm': 'Times', 'mathtext.it': 'Times:italic', 'mathtext.bf': 'Times:bold', 'font.family': 'serif'}
 >>> fonts.icml2022(family="serif")
-{'font.family': 'serif',
- 'font.serif': ['Times'],
- 'mathtext.bf': 'Times:bold',
- 'mathtext.fontset': 'stix',
- 'mathtext.it': 'Times:italic',
- 'mathtext.rm': 'Times',
- 'text.usetex': False}
+{'text.usetex': False, 'font.serif': ['Times'], 'mathtext.fontset': 'stix', 'mathtext.rm': 'Times', 'mathtext.it': 'Times:italic', 'mathtext.bf': 'Times:bold', 'font.family': 'serif'}
 >>> fonts.icml2022_tex(family="sans-serif")
-{'font.family': 'sans-serif',
- 'text.latex.preamble': '\\usepackage{times} '
-                        '\\renewcommand{\\familydefault}{\\sfdefault} '
-                        '\\usepackage{sansmath} \\sansmath',
- 'text.usetex': True}
+{'text.usetex': True, 'font.family': 'sans-serif', 'text.latex.preamble': '\\usepackage{times} \\renewcommand{\\familydefault}{\\sfdefault} \\usepackage{sansmath} \\sansmath'}
+
 ```
+
 and if you want to give your plots a makeover (albeit a slightly opinionated one) with a single line of code,
 consider the `axes.lines()` setting.
+
 ```python
 >>> from tueplots import axes
 >>> axes.lines()
-{'axes.axisbelow': True,
- 'axes.linewidth': 0.5,
- 'grid.linewidth': 0.5,
- 'legend.edgecolor': 'inherit',
- 'lines.linewidth': 1.0,
- 'patch.linewidth': 0.5,
- 'xtick.major.size': 3.0,
- 'xtick.major.width': 0.5,
- 'xtick.minor.size': 2.0,
- 'xtick.minor.width': 0.25,
- 'ytick.major.size': 3.0,
- 'ytick.major.width': 0.5,
- 'ytick.minor.size': 2.0,
- 'ytick.minor.width': 0.25}
+{'axes.linewidth': 0.5, 'lines.linewidth': 1.0, 'xtick.major.width': 0.5, 'ytick.major.width': 0.5, 'xtick.minor.width': 0.25, 'ytick.minor.width': 0.25, 'xtick.major.size': 3.0, 'ytick.major.size': 3.0, 'xtick.minor.size': 2.0, 'ytick.minor.size': 2.0, 'grid.linewidth': 0.5, 'patch.linewidth': 0.5, 'legend.edgecolor': 'inherit', 'axes.axisbelow': True}
 >>> axes.lines(base_width=0.5)
-{'axes.axisbelow': True,
- 'axes.linewidth': 0.5,
- 'grid.linewidth': 0.5,
- 'legend.edgecolor': 'inherit',
- 'lines.linewidth': 1.0,
- 'patch.linewidth': 0.5,
- 'xtick.major.size': 3.0,
- 'xtick.major.width': 0.5,
- 'xtick.minor.size': 2.0,
- 'xtick.minor.width': 0.25,
- 'ytick.major.size': 3.0,
- 'ytick.major.width': 0.5,
- 'ytick.minor.size': 2.0,
- 'ytick.minor.width': 0.25}
+{'axes.linewidth': 0.5, 'lines.linewidth': 1.0, 'xtick.major.width': 0.5, 'ytick.major.width': 0.5, 'xtick.minor.width': 0.25, 'ytick.minor.width': 0.25, 'xtick.major.size': 3.0, 'ytick.major.size': 3.0, 'xtick.minor.size': 2.0, 'ytick.minor.size': 2.0, 'grid.linewidth': 0.5, 'patch.linewidth': 0.5, 'legend.edgecolor': 'inherit', 'axes.axisbelow': True}
+
 ```

--- a/docs/source/getting_started/usage_example.md
+++ b/docs/source/getting_started/usage_example.md
@@ -7,7 +7,9 @@ For example, figure sizes can be tailored straightforwardly to some common journ
 >>> from tueplots import figsizes
 >>> figsizes.jmlr2001()["figure.figsize"]
 (6.0, 1.8541019662496847)
+
 ```
+
 within one module, the functions have a unified interface (wherever possible)
 ```python
 >>> figsizes.jmlr2001(nrows=2)["figure.figsize"]
@@ -18,9 +20,8 @@ within one module, the functions have a unified interface (wherever possible)
 >>>
 >>> # The full output:
 >>> figsizes.icml2022_full(nrows=4)
-{'figure.autolayout': False,
- 'figure.constrained_layout.use': True,
- 'figure.figsize': (6.75, 8.343458848123582)}
+{'figure.figsize': (6.75, 8.343458848123582), 'figure.constrained_layout.use': True, 'figure.autolayout': False}
+
 ```
 
 There are also predefined color constants. For example, those based on the corporate design of the University of Tuebingen:
@@ -32,6 +33,7 @@ array([0.21568627, 0.25490196, 0.29019608])
 >>>
 >>> rgb.tue_gray
 array([0.68627451, 0.70196078, 0.71764706])
+
 ```
 
 Most of the output types of functions in `tueplots` are dictionaries that are directly compatible with matplotlib's `rcParam` language.
@@ -39,10 +41,7 @@ Most of the output types of functions in `tueplots` are dictionaries that are di
 >>> from tueplots import markers
 >>>
 >>> markers.inverted()
-{'lines.markeredgecolor': 'auto',
- 'lines.markeredgewidth': 0.75,
- 'lines.markerfacecolor': 'white'}
-
+{'lines.markeredgecolor': 'auto', 'lines.markerfacecolor': 'white', 'lines.markeredgewidth': 0.75}
 
 >>> import matplotlib.pyplot as plt
 
@@ -52,6 +51,7 @@ Most of the output types of functions in `tueplots` are dictionaries that are di
 
 >>> # Or change your global configuration
 >>> plt.rcParams.update(markers.inverted())
+
 ```
 
 For more detailed tutorials, please have a look at the examples in the `examples/` directory.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = pytest, black, isort, byexample, pylint
+envlist = pytest, doctest, black, isort, byexample, pylint
 isolated_build = True
 
 [testenv]
@@ -8,11 +8,17 @@ description = Executing tests with pytest
 deps =
     pytest < 7.0.0  # https://github.com/smarie/python-pytest-cases/issues/251
     pytest-cases
+commands =
+    pytest {posargs}
+
+[testenv:doctest]
+description = Executing code snippets in readme with doctest
+deps =
     matplotlib
 commands =
-    pytest --verbose {posargs}
-    python -m doctest -v docs/source/getting_started/application_icml2022.md
-    python -m doctest -v docs/source/getting_started/usage_example.md
+    python -m doctest docs/source/getting_started/application_icml2022.md
+    python -m doctest docs/source/getting_started/usage_example.md
+
 
 [testenv:black]
 description = Code linting with Black

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,11 @@ description = Executing tests with pytest
 deps =
     pytest < 7.0.0  # https://github.com/smarie/python-pytest-cases/issues/251
     pytest-cases
-    byexample
     matplotlib
 commands =
     pytest --verbose {posargs}
-    byexample -l python --timeout 20 docs/source/docs_dev/*.md
-    byexample -l python --timeout 20 docs/source/getting_started/*.md
+    python -m doctest -v docs/source/getting_started/application_icml2022.md
+    python -m doctest -v docs/source/getting_started/usage_example.md
 
 [testenv:black]
 description = Code linting with Black

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ isolated_build = True
 [testenv]
 description = Executing tests with pytest
 deps =
-    pytest < 7.0.0  # https://github.com/smarie/python-pytest-cases/issues/251
+    pytest
     pytest-cases
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,12 @@ description = Executing tests with pytest
 deps =
     pytest < 7.0.0  # https://github.com/smarie/python-pytest-cases/issues/251
     pytest-cases
-
-commands = pytest --verbose {posargs}
+    byexample
+    matplotlib
+commands =
+    pytest --verbose {posargs}
+    byexample -l python --timeout 20 docs/source/docs_dev/*.md
+    byexample -l python --timeout 20 docs/source/getting_started/*.md
 
 [testenv:black]
 description = Code linting with Black
@@ -28,15 +32,6 @@ deps =
 commands =
     isort --check --diff .
     nbqa isort --check --diff .
-
-[testenv:byexample]
-description = Run the snippets in the Readme
-deps =
-    byexample
-    matplotlib
-commands =
-    byexample -l python --timeout 20 docs/source/docs_dev/*.md
-    byexample -l python --timeout 20 docs/source/getting_started/*.md
 
 [testenv:pylint]
 description = Linting (pylint)


### PR DESCRIPTION
* Run markdown-file-snippets with  `doctest` instead of `byexample` (which is more windows- and macOS-compatible)
* Run tests for different OS and different python versions
* Include the doctests into the test workflow
* Fix the readme-formatting-issues implied by the byexample-to-doctest switch
* Remove version pin for pytest