### PR TITLE
light face for roboto in beamer_moml

### DIFF
--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -118,8 +118,10 @@ def beamer_moml():
     """Fonts that are compatible with the beamer template of the method-of-machine-learning group in Tübingen."""
     return {
         "text.usetex": False,
-        "font.serif": ["Roboto Condensed"],
-        "font.family": "serif",
+        "mathtext.fontset": "custom",
+        "mathtext.it": "sans:italic",
+        "font.sans-serif": ["Roboto Condensed"],
+        "font.family": "sans-serif",
         "font.weight": "light",
         "axes.labelweight": "light",
         "axes.titleweight": "light",


### PR DESCRIPTION
This fixes #94. As simple solution that does not require `text.usetex`. 

Thanks @pnkraemer for the help! Nice team effort! A fun thing to do while invigilating an exam. :) 