### PR TITLE
AISTATS 2023 style

### DIFF
--- a/tests/test_rc_params_cases/case_bundles.py
+++ b/tests/test_rc_params_cases/case_bundles.py
@@ -18,6 +18,11 @@ def case_bundles_aistats2022(column):
     return bundles.aistats2022(column=column, nrows=2, ncols=2, family="serif")
 
 
+@pytest_cases.parametrize(column=["full", "half"])
+def case_bundles_aistats2023(column):
+    return bundles.aistats2023(column=column, nrows=2, ncols=2, family="serif")
+
+
 @pytest_cases.parametrize(usetex=[True, False])
 def case_bundles_neurips2021(usetex):
     return bundles.neurips2021(usetex=usetex, nrows=2, ncols=2, family="serif")

--- a/tests/test_rc_params_cases/case_figsizes.py
+++ b/tests/test_rc_params_cases/case_figsizes.py
@@ -20,6 +20,14 @@ def case_figsizes_aistats2022_half():
     return figsizes.aistats2022_half(nrows=2, ncols=3, height_to_width_ratio=1.0)
 
 
+def case_figsizes_aistats2023_full():
+    return figsizes.aistats2023_full(nrows=2, ncols=3, height_to_width_ratio=1.0)
+
+
+def case_figsizes_aistats2023_half():
+    return figsizes.aistats2023_half(nrows=2, ncols=3, height_to_width_ratio=1.0)
+
+
 def case_figsizes_cvpr2022_half():
     return figsizes.cvpr2022_half(nrows=2, ncols=3, height_to_width_ratio=1.0)
 

--- a/tests/test_rc_params_cases/case_fonts.py
+++ b/tests/test_rc_params_cases/case_fonts.py
@@ -64,5 +64,13 @@ def case_fonts_aistats2022_tex_default():
     return fonts.aistats2022_tex()
 
 
+def case_fonts_aistats2023_tex_default():
+    return fonts.aistats2023_tex()
+
+
 def case_fonts_aistats2022_tex_custom():
     return fonts.aistats2022_tex(family="serif")
+
+
+def case_fonts_aistats2023_tex_custom():
+    return fonts.aistats2023_tex(family="serif")

--- a/tests/test_rc_params_cases/case_fontsizes.py
+++ b/tests/test_rc_params_cases/case_fontsizes.py
@@ -19,6 +19,10 @@ def case_fontsizes_aistats2022():
     return fontsizes.aistats2022()
 
 
+def case_fontsizes_aistats2023():
+    return fontsizes.aistats2023()
+
+
 def case_fontsizes_jmlr2001():
     return fontsizes.jmlr2001()
 

--- a/tueplots/bundles.py
+++ b/tueplots/bundles.py
@@ -29,6 +29,17 @@ def aistats2022(*, column="half", nrows=1, ncols=1, family="serif"):
     return {**font_config, **size, **fontsize_config}
 
 
+def aistats2023(*, column="half", nrows=1, ncols=1, family="serif"):
+    """AISTATS 2023 bundle."""
+    if column == "half":
+        size = figsizes.aistats2023_half(nrows=nrows, ncols=ncols)
+    elif column == "full":
+        size = figsizes.aistats2023_full(nrows=nrows, ncols=ncols)
+    font_config = fonts.aistats2023_tex(family=family)
+    fontsize_config = fontsizes.aistats2023()
+    return {**font_config, **size, **fontsize_config}
+
+
 def jmlr2001(*, rel_width=1.0, nrows=1, ncols=1, family="serif"):
     """JMLR 2001 bundle."""
     size = figsizes.jmlr2001(rel_width=rel_width, nrows=nrows, ncols=ncols)

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -17,25 +17,35 @@ _PAD_INCHES = 0.015
 
 def icml2022_half(**kwargs):
     """Double-column (half-width) figures for ICML 2022."""
-    return _icml2022_and_aistats2022_half(**kwargs)
+    return _icml_and_aistats_common_half(**kwargs)
 
 
 def icml2022_full(**kwargs):
     """Single-column (full-width) figures for ICML 2022."""
-    return _icml2022_and_aistats2022_full(**kwargs)
+    return _icml_and_aistats_common_full(**kwargs)
 
 
 def aistats2022_half(**kwargs):
     """Double-column (half-width) figures for AISTATS 2022."""
-    return _icml2022_and_aistats2022_half(**kwargs)
+    return _icml_and_aistats_common_half(**kwargs)
 
 
 def aistats2022_full(**kwargs):
     """Single-column (full-width) figures for AISTATS 2022."""
-    return _icml2022_and_aistats2022_full(**kwargs)
+    return _icml_and_aistats_common_full(**kwargs)
 
 
-def _icml2022_and_aistats2022_half(
+def aistats2023_half(**kwargs):
+    """Double-column (half-width) figures for AISTATS 2023."""
+    return _icml_and_aistats_common_half(**kwargs)
+
+
+def aistats2023_full(**kwargs):
+    """Single-column (full-width) figures for AISTATS 2023."""
+    return _icml_and_aistats_common_full(**kwargs)
+
+
+def _icml_and_aistats_common_half(
     *,
     nrows=1,
     ncols=1,
@@ -59,7 +69,7 @@ def _icml2022_and_aistats2022_half(
     )
 
 
-def _icml2022_and_aistats2022_full(
+def _icml_and_aistats_common_full(
     *,
     rel_width=1.0,
     nrows=1,

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -69,7 +69,25 @@ def icml2022(*, family="serif"):
 
 def icml2022_tex(*, family="serif"):
     """Fonts for ICML 2022. LaTeX version."""
+    return _tex_times(family=family)
 
+
+def jmlr2001_tex(*, family="serif"):
+    """Fonts for JMLR. LaTeX version."""
+    return _tex_computer_modern(family=family)
+
+
+def aistats2022_tex(*, family="serif"):
+    """Fonts for AISTATS 2022. LaTeX version."""
+    return _tex_computer_modern(family=family)
+
+
+def aistats2023_tex(*, family="serif"):
+    """Fonts for AISTATS 2023. LaTeX version."""
+    return _tex_times(family=family)
+
+
+def _tex_times(*, family):
     preamble = r"\usepackage{times} "
     if family == "serif":
         return {
@@ -87,17 +105,7 @@ def icml2022_tex(*, family="serif"):
     }
 
 
-def jmlr2001_tex(*, family="serif"):
-    """Fonts for JMLR. LaTeX version."""
-    return _tex_computer_modern(family=family)
-
-
-def aistats2022_tex(*, family="serif"):
-    """Fonts for AISTATS 2022. LaTeX version."""
-    return _tex_computer_modern(family=family)
-
-
-def _tex_computer_modern(*, family="serif"):
+def _tex_computer_modern(*, family):
     if family == "serif":
         return {
             "text.usetex": True,

--- a/tueplots/fontsizes.py
+++ b/tueplots/fontsizes.py
@@ -26,6 +26,11 @@ def aistats2022(*, default_smaller=1):
     return _from_base(base=10 - default_smaller)
 
 
+def aistats2023(*, default_smaller=1):
+    """Font size for AISTATS 2023."""
+    return _from_base(base=10 - default_smaller)
+
+
 def jmlr2001(*, default_smaller=1):
     """Font size for JMLR 2021."""
     return _from_base(base=10.95 - default_smaller)


### PR DESCRIPTION
This PR introduces the styles for AISTATS 2023. The formats are essentially the same, but the font has changed to ``\usepackage{times}``, which is more similar to ICML now).