### PR TITLE
Add list of supported venues to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ We like all the colors, frame-styles, markers, or linewidths.
 But we _do_ think that figure sizes should match the text-width in your publication, 
 and that the font-size in the plot should be readable, and similar to the rest of the paper/presentation/....
 
+## Supported Venues
+
+The following venues are currently supported by `tueplots` out of the box.
+
+| tueplots bundle                 | Venue Name and Year                                                      |
+|---------------------------------|--------------------------------------------------------------------------|
+| `tueplots.bundle.icml2022()`    | International Conference on Machine Learning, 2022                       |
+| `tueplots.bundle.aistats2022()` | International Conference on Artificial Intelligence and Statistics, 2022 |
+| `tueplots.bundle.aistats2023()` | International Conference on Artificial Intelligence and Statistics, 2023 |
+| `tueplots.bundle.jmlr2001()`    | Journal of Machine Learning Research, 2001                               |
+| `tueplots.bundle.neurips2021()` | Conference on Neural Information Processing Systems, 2021                |
+| `tueplots.bundle.neurips2022()` | Conference on Neural Information Processing Systems, 2022                |
+| `tueplots.bundle.iclr2023()`    | International Conference on Learning Representations, 2023               |
+
+
 ## Getting started 
 
 Installing `tueplots` is explained [**here**](https://tueplots.readthedocs.io/en/latest/getting_started/installation.html).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ A more specific tutorial, applying `tueplots` to figures intended for ICML 2022,
 If something is not working as promised, please refer to the [**troubleshooting**](https://tueplots.readthedocs.io/en/latest/getting_started/troubleshooting.html) site.
 For more advanced tutorials, you may refer to the example notebooks.
 
+## Supported Venues
+
+The following venues are currently supported by tueplots out of the box as pre-configured bundles:
+
+- Conference on Neural Information Processing Systems (NeurIPS)
+- International Conference on Artificial Intelligence and Statistics (AISTATS)
+- International Conference on Learning Representations (ICLR)
+- International Conference on Machine Learning (ICML)
+- Journal of Machine Learning Research (JMLR)
+
+For further details on the available bundles, check out the [`tueplots.bundles` API documentation](https://tueplots.readthedocs.io/en/latest/docs_api/tueplots.bundles.html).
+
 ## Related packages
 There are similar packages to `tueplots` (with different foci, respectively):
 * Seaborn: https://seaborn.pydata.org/index.html

--- a/README.md
+++ b/README.md
@@ -47,21 +47,6 @@ We like all the colors, frame-styles, markers, or linewidths.
 But we _do_ think that figure sizes should match the text-width in your publication, 
 and that the font-size in the plot should be readable, and similar to the rest of the paper/presentation/....
 
-## Supported Venues
-
-The following venues are currently supported by `tueplots` out of the box.
-
-| tueplots bundle                 | Venue Name and Year                                                      |
-|---------------------------------|--------------------------------------------------------------------------|
-| `tueplots.bundle.icml2022()`    | International Conference on Machine Learning, 2022                       |
-| `tueplots.bundle.aistats2022()` | International Conference on Artificial Intelligence and Statistics, 2022 |
-| `tueplots.bundle.aistats2023()` | International Conference on Artificial Intelligence and Statistics, 2023 |
-| `tueplots.bundle.jmlr2001()`    | Journal of Machine Learning Research, 2001                               |
-| `tueplots.bundle.neurips2021()` | Conference on Neural Information Processing Systems, 2021                |
-| `tueplots.bundle.neurips2022()` | Conference on Neural Information Processing Systems, 2022                |
-| `tueplots.bundle.iclr2023()`    | International Conference on Learning Representations, 2023               |
-
-
 ## Getting started 
 
 Installing `tueplots` is explained [**here**](https://tueplots.readthedocs.io/en/latest/getting_started/installation.html).

--- a/README.md
+++ b/README.md
@@ -55,18 +55,6 @@ A more specific tutorial, applying `tueplots` to figures intended for ICML 2022,
 If something is not working as promised, please refer to the [**troubleshooting**](https://tueplots.readthedocs.io/en/latest/getting_started/troubleshooting.html) site.
 For more advanced tutorials, you may refer to the example notebooks.
 
-## Supported Venues
-
-The following venues are currently supported by tueplots out of the box as pre-configured bundles:
-
-- Conference on Neural Information Processing Systems (NeurIPS)
-- International Conference on Artificial Intelligence and Statistics (AISTATS)
-- International Conference on Learning Representations (ICLR)
-- International Conference on Machine Learning (ICML)
-- Journal of Machine Learning Research (JMLR)
-
-For further details on the available bundles, check out the [`tueplots.bundles` API documentation](https://tueplots.readthedocs.io/en/latest/docs_api/tueplots.bundles.html).
-
 ## Related packages
 There are similar packages to `tueplots` (with different foci, respectively):
 * Seaborn: https://seaborn.pydata.org/index.html

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,20 @@ It produces configurations that are compatible with matplotlib's `rcParams`,
 and provides fonts, figure sizes, font sizes, color schemes, and more, for a number of publication formats.
 
 
+Supported Venues
+----------------
+
+The following venues are currently supported by TUEplots out of the box as pre-configured bundles:
+
+- Conference on Neural Information Processing Systems (NeurIPS)
+- International Conference on Artificial Intelligence and Statistics (AISTATS)
+- International Conference on Learning Representations (ICLR)
+- International Conference on Machine Learning (ICML)
+- Journal of Machine Learning Research (JMLR)
+
+For further details on the available bundles, check out the `tueplots.bundles API documentation <https://tueplots.readthedocs.io/en/latest/docs_api/tueplots.bundles.html>`_.
+
+
 .. toctree::
    :maxdepth: 1
    :caption: Getting started

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,29 @@ that adapts your figure sizes to formats more suitable for scientific publicatio
 It produces configurations that are compatible with matplotlib's `rcParams`,
 and provides fonts, figure sizes, font sizes, color schemes, and more, for a number of publication formats.
 
+Supported Venues
+----------------
+
+The following venues are currently supported by `tueplots` out of the box.
+
++---------------------------------+--------------------------------------------------------------------------+
+| tueplots bundle                 | Venue Name and Year                                                      |
++=================================+==========================================================================+
+| `tueplots.bundle.icml2022()`    | International Conference on Machine Learning, 2022                       |
++---------------------------------+--------------------------------------------------------------------------+
+| `tueplots.bundle.aistats2022()` | International Conference on Artificial Intelligence and Statistics, 2022 |
++---------------------------------+--------------------------------------------------------------------------+
+| `tueplots.bundle.aistats2023()` | International Conference on Artificial Intelligence and Statistics, 2023 |
++---------------------------------+--------------------------------------------------------------------------+
+| `tueplots.bundle.jmlr2001()`    | Journal of Machine Learning Research, 2001                               |
++---------------------------------+--------------------------------------------------------------------------+
+| `tueplots.bundle.neurips2021()` | Conference on Neural Information Processing Systems, 2021                |
++---------------------------------+--------------------------------------------------------------------------+
+| `tueplots.bundle.neurips2022()` | Conference on Neural Information Processing Systems, 2022                |
++---------------------------------+--------------------------------------------------------------------------+
+| `tueplots.bundle.iclr2023()`    | International Conference on Learning Representations, 2023               |
++---------------------------------+--------------------------------------------------------------------------+
+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,29 +11,6 @@ that adapts your figure sizes to formats more suitable for scientific publicatio
 It produces configurations that are compatible with matplotlib's `rcParams`,
 and provides fonts, figure sizes, font sizes, color schemes, and more, for a number of publication formats.
 
-Supported Venues
-----------------
-
-The following venues are currently supported by `tueplots` out of the box.
-
-+---------------------------------+--------------------------------------------------------------------------+
-| tueplots bundle                 | Venue Name and Year                                                      |
-+=================================+==========================================================================+
-| `tueplots.bundle.icml2022()`    | International Conference on Machine Learning, 2022                       |
-+---------------------------------+--------------------------------------------------------------------------+
-| `tueplots.bundle.aistats2022()` | International Conference on Artificial Intelligence and Statistics, 2022 |
-+---------------------------------+--------------------------------------------------------------------------+
-| `tueplots.bundle.aistats2023()` | International Conference on Artificial Intelligence and Statistics, 2023 |
-+---------------------------------+--------------------------------------------------------------------------+
-| `tueplots.bundle.jmlr2001()`    | Journal of Machine Learning Research, 2001                               |
-+---------------------------------+--------------------------------------------------------------------------+
-| `tueplots.bundle.neurips2021()` | Conference on Neural Information Processing Systems, 2021                |
-+---------------------------------+--------------------------------------------------------------------------+
-| `tueplots.bundle.neurips2022()` | Conference on Neural Information Processing Systems, 2022                |
-+---------------------------------+--------------------------------------------------------------------------+
-| `tueplots.bundle.iclr2023()`    | International Conference on Learning Representations, 2023               |
-+---------------------------------+--------------------------------------------------------------------------+
-
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ The following venues are currently supported by TUEplots out of the box as pre-c
 - International Conference on Machine Learning (ICML)
 - Journal of Machine Learning Research (JMLR)
 
-For further details on the available bundles, check out the `tueplots.bundles API documentation <https://tueplots.readthedocs.io/en/latest/docs_api/tueplots.bundles.html>`_.
+For further details on the available bundles, check out the `tueplots.bundles API documentation <docs_api/tueplots.bundles.rst>`_.
 
 
 .. toctree::


### PR DESCRIPTION
First time users might be interested in a quick overview of whether their targeted venue is supported by tueplots. While this information can be found in the [API docs](https://tueplots.readthedocs.io/en/latest/docs_api/tueplots.bundles.html), I think it would be good to provide an overview on the "landing page" of this package, i.e., either the GitHub README file or the docs index file.