### PR TITLE
added a bundle for TMLR

### DIFF
--- a/tests/test_rc_params_cases/case_bundles.py
+++ b/tests/test_rc_params_cases/case_bundles.py
@@ -42,6 +42,10 @@ def case_bundles_jmlr2001():
     return bundles.jmlr2001(nrows=2, ncols=2, family="serif")
 
 
+def case_bundles_tmlr2023():
+    return bundles.tmlr2023(nrows=2, ncols=2, family="serif")
+
+
 def case_bundles_beamer_moml():
     return bundles.beamer_moml(rel_width=0.9, rel_height=0.9)
 

--- a/tueplots/bundles.py
+++ b/tueplots/bundles.py
@@ -48,6 +48,14 @@ def jmlr2001(*, rel_width=1.0, nrows=1, ncols=1, family="serif"):
     return {**font_config, **size, **fontsize_config}
 
 
+def tmlr2023(*, rel_width=1.0, nrows=1, ncols=1, family="serif"):
+    """TMLR 2023 bundle."""
+    size = figsizes.tmlr2023(rel_width=rel_width, nrows=nrows, ncols=ncols)
+    font_config = fonts.tmlr2023_tex(family=family)
+    fontsize_config = fontsizes.tmlr2023()
+    return {**font_config, **size, **fontsize_config}
+
+
 def neurips2021(*, usetex=True, rel_width=1.0, nrows=1, ncols=1, family="serif"):
     """Neurips 2021 bundle."""
     if usetex is True:

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -194,8 +194,7 @@ def tmlr2023(
 ):
     """TMLR figure size.
 
-    Source: https://www.overleaf.com/latex/templates/tmlr-journal-submissions/mwchznnhdtwx
-    """
+    Source: https://www.jmlr.org/tmlr/author-guide.html"""
 
     figsize = _from_base_in(
         base_width_in=6.5,

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -182,6 +182,36 @@ def jmlr2001(
     )
 
 
+def tmlr2023(
+    *,
+    rel_width=1.0,
+    nrows=1,
+    ncols=2,
+    constrained_layout=True,
+    tight_layout=False,
+    height_to_width_ratio=_GOLDEN_RATIO,
+    pad_inches=_PAD_INCHES,
+):
+    """TMLR figure size.
+
+    Source: https://www.overleaf.com/latex/templates/tmlr-journal-submissions/mwchznnhdtwx
+    """
+
+    figsize = _from_base_in(
+        base_width_in=6.5,
+        rel_width=rel_width,
+        height_to_width_ratio=height_to_width_ratio,
+        nrows=nrows,
+        ncols=ncols,
+    )
+    return _figsize_to_output_dict(
+        figsize=figsize,
+        constrained_layout=constrained_layout,
+        tight_layout=tight_layout,
+        pad_inches=pad_inches,
+    )
+
+
 def neurips2021(
     *,
     rel_width=1.0,

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -87,6 +87,11 @@ def jmlr2001_tex(*, family="serif"):
     return _tex_computer_modern(family=family)
 
 
+def tmlr2023_tex(*, family="serif"):
+    """Fonts for TMLR. LaTeX version."""
+    return _tex_computer_modern(family=family)
+
+
 def aistats2022_tex(*, family="serif"):
     """Fonts for AISTATS 2022. LaTeX version."""
     return _tex_computer_modern(family=family)

--- a/tueplots/fontsizes.py
+++ b/tueplots/fontsizes.py
@@ -41,6 +41,11 @@ def jmlr2001(*, default_smaller=1):
     return _from_base(base=10.95 - default_smaller)
 
 
+def tmlr2023(*, default_smaller=1):
+    """Font size for TMLR 2023."""
+    return _from_base(base=10 - default_smaller)
+
+
 def beamer_moml(*, default_smaller=1):
     """Font size for a beamer slide in aspectratio 16:9 with 10pt font."""
     return _from_base(base=10 - default_smaller)


### PR DESCRIPTION
I have added a bundle for [TMLR](https://jmlr.org/tmlr/), based on the [official template](https://www.overleaf.com/latex/templates/tmlr-journal-submissions/mwchznnhdtwx). It's largely based on the JMLR template, with slightly wider text (6.5 inches, instead of 6), and fontsize 10 instead of 10.95.