### PR TITLE
Reorder helper functions in fonts.py, clarify 'times' vs 'times new roman', and clarify 'usepackage{times}' vs 'usepackage{ptm}'

### DIFF
--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -61,52 +61,6 @@ def cvpr2024(*, family="serif"):
     return _neurips_and_iclr_common(family=family)
 
 
-def _neurips_and_iclr_common(*, family="serif"):
-    """Default fonts for Neurips."""
-    return {
-        "text.usetex": False,
-        "font.serif": ["Times New Roman"],
-        "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
-        "mathtext.rm": "Times New Roman",
-        "mathtext.it": "Times New Roman:italic",
-        "mathtext.bf": "Times New Roman:bold",
-        "font.family": family,
-    }
-
-
-def _neurips_and_iclr_tex_common(*, family="serif"):
-    """Default fonts for Neurips. LaTeX version."""
-    preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
-    if family == "serif":
-        return {
-            "text.usetex": True,
-            "font.family": "serif",
-            "text.latex.preamble": preamble,
-        }
-    preamble += (
-        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
-    )
-    return {
-        "text.usetex": True,
-        "font.family": "sans-serif",
-        "text.latex.preamble": preamble,
-    }
-
-
-def icml2022(*, family="serif"):
-    """Fonts for ICML 2022."""
-
-    return {
-        "text.usetex": False,
-        "font.serif": ["Times"],
-        "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
-        "mathtext.rm": "Times",
-        "mathtext.it": "Times:italic",
-        "mathtext.bf": "Times:bold",
-        "font.family": family,
-    }
-
-
 def icml2022_tex(*, family="serif"):
     """Fonts for ICML 2022. LaTeX version."""
     return _tex_times(family=family)
@@ -140,6 +94,52 @@ def uai2023_tex(*, family="serif"):
 def aaai2024_tex(*, family="serif"):
     """Fonts for AAAI 2024. LaTeX version."""
     return _tex_times(family=family)
+
+
+def icml2022(*, family="serif"):
+    """Fonts for ICML 2022."""
+
+    return {
+        "text.usetex": False,
+        "font.serif": ["Times"],
+        "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
+        "mathtext.rm": "Times",
+        "mathtext.it": "Times:italic",
+        "mathtext.bf": "Times:bold",
+        "font.family": family,
+    }
+
+
+def _neurips_and_iclr_common(*, family="serif"):
+    """Default fonts for Neurips."""
+    return {
+        "text.usetex": False,
+        "font.serif": ["Times New Roman"],
+        "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
+        "mathtext.rm": "Times New Roman",
+        "mathtext.it": "Times New Roman:italic",
+        "mathtext.bf": "Times New Roman:bold",
+        "font.family": family,
+    }
+
+
+def _neurips_and_iclr_tex_common(*, family="serif"):
+    """Default fonts for Neurips. LaTeX version."""
+    preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
+    if family == "serif":
+        return {
+            "text.usetex": True,
+            "font.family": "serif",
+            "text.latex.preamble": preamble,
+        }
+    preamble += (
+        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
+    )
+    return {
+        "text.usetex": True,
+        "font.family": "sans-serif",
+        "text.latex.preamble": preamble,
+    }
 
 
 def _tex_times(*, family):

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -147,7 +147,7 @@ def _times(*, family="serif"):
 
     Used, e.g., for ICML 2022.
     """
-    # todo: remove default family.
+
     return {
         "text.usetex": False,
         "font.serif": ["Times"],

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -3,178 +3,114 @@
 
 def neurips2021(*, family="serif"):
     """Fonts for Neurips 2021."""
-    return _neurips_and_iclr_common(family=family)
+    # NeurIPS' style-files states that it uses Times New Roman
+    # font, but includes the 'ptm' package, which implements
+    # the 'Times' font.
+    # Therefore, refer to 'Times' instead of 'Times New Roman'
+    return _times(family=family)
 
 
 def neurips2021_tex(*, family="serif"):
     """Fonts for Neurips 2021. LaTeX version."""
-    return _neurips_and_iclr_tex_common(family=family)
+    return _times_tex_via_pkg_ptm(family=family)
 
 
 def neurips2022(*, family="serif"):
     """Fonts for Neurips 2022."""
-    return _neurips_and_iclr_common(family=family)
+    # NeurIPS' style-files states that it uses Times New Roman
+    # font, but includes the 'ptm' package, which implements
+    # the 'Times' font.
+    # Therefore, refer to 'Times' instead of 'Times New Roman'
+    return _times(family=family)
 
 
 def neurips2022_tex(*, family="serif"):
     """Fonts for Neurips 2022. LaTeX version."""
-    return _neurips_and_iclr_tex_common(family=family)
+    return _times_tex_via_pkg_ptm(family=family)
 
 
 def neurips2023(*, family="serif"):
     """Fonts for Neurips 2023."""
-    return _neurips_and_iclr_common(family=family)
+    # NeurIPS' style-files states that it uses Times New Roman
+    # font, but includes the 'ptm' package, which implements
+    # the 'Times' font.
+    # Therefore, refer to 'Times' instead of 'Times New Roman'
+    return _times(family=family)
 
 
 def neurips2023_tex(*, family="serif"):
     """Fonts for Neurips 2023. LaTeX version."""
-    return _neurips_and_iclr_tex_common(family=family)
+    return _times_tex_via_pkg_ptm(family=family)
 
 
 def iclr2023_tex(*, family="serif"):
     """Fonts for ICLR 2023. LaTeX version."""
-    return _neurips_and_iclr_tex_common(family=family)
+    return _times_tex_via_pkg_times(family=family)
 
 
 def iclr2024_tex(*, family="serif"):
     """Fonts for ICLR 2024. LaTeX version."""
-    return _neurips_and_iclr_tex_common(family=family)
+    return _times_tex_via_pkg_times(family=family)
 
 
 def iclr2023(*, family="serif"):
     """Fonts for ICLR 2023. LaTeX version."""
-    return _neurips_and_iclr_common(family=family)
+    return _times(family=family)
 
 
 def iclr2024(*, family="serif"):
     """Fonts for ICLR 2024. LaTeX version."""
-    return _neurips_and_iclr_common(family=family)
+    return _times(family=family)
 
 
 def cvpr2024_tex(*, family="serif"):
     """Fonts for CVPR 2024. LaTeX version."""
-    return _neurips_and_iclr_tex_common(family=family)
+    return _times_tex_via_pkg_ptm(family=family)
 
 
 def cvpr2024(*, family="serif"):
     """Fonts for CVPR 2024. LaTeX version."""
-    return _neurips_and_iclr_common(family=family)
+    return _times(family=family)
 
 
 def icml2022_tex(*, family="serif"):
     """Fonts for ICML 2022. LaTeX version."""
-    return _tex_times(family=family)
+    return _times_tex_via_pkg_times(family=family)
 
 
 def jmlr2001_tex(*, family="serif"):
     """Fonts for JMLR. LaTeX version."""
-    return _tex_computer_modern(family=family)
+    return _computer_modern_tex(family=family)
 
 
 def tmlr2023_tex(*, family="serif"):
     """Fonts for TMLR. LaTeX version."""
-    return _tex_computer_modern(family=family)
+    return _computer_modern_tex(family=family)
 
 
 def aistats2022_tex(*, family="serif"):
     """Fonts for AISTATS 2022. LaTeX version."""
-    return _tex_computer_modern(family=family)
+    return _computer_modern_tex(family=family)
 
 
 def aistats2023_tex(*, family="serif"):
     """Fonts for AISTATS 2023. LaTeX version."""
-    return _tex_times(family=family)
+    return _times_tex_via_pkg_times(family=family)
 
 
 def uai2023_tex(*, family="serif"):
     """Fonts for UAI 2023. LaTeX version."""
-    return _tex_times(family=family)
+    return _times_tex_via_pkg_times(family=family)
 
 
 def aaai2024_tex(*, family="serif"):
     """Fonts for AAAI 2024. LaTeX version."""
-    return _tex_times(family=family)
+    return _times_tex_via_pkg_times(family=family)
 
 
 def icml2022(*, family="serif"):
     """Fonts for ICML 2022."""
-
-    return {
-        "text.usetex": False,
-        "font.serif": ["Times"],
-        "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
-        "mathtext.rm": "Times",
-        "mathtext.it": "Times:italic",
-        "mathtext.bf": "Times:bold",
-        "font.family": family,
-    }
-
-
-def _neurips_and_iclr_common(*, family="serif"):
-    """Default fonts for Neurips."""
-    return {
-        "text.usetex": False,
-        "font.serif": ["Times New Roman"],
-        "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
-        "mathtext.rm": "Times New Roman",
-        "mathtext.it": "Times New Roman:italic",
-        "mathtext.bf": "Times New Roman:bold",
-        "font.family": family,
-    }
-
-
-def _neurips_and_iclr_tex_common(*, family="serif"):
-    """Default fonts for Neurips. LaTeX version."""
-    preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
-    if family == "serif":
-        return {
-            "text.usetex": True,
-            "font.family": "serif",
-            "text.latex.preamble": preamble,
-        }
-    preamble += (
-        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
-    )
-    return {
-        "text.usetex": True,
-        "font.family": "sans-serif",
-        "text.latex.preamble": preamble,
-    }
-
-
-def _tex_times(*, family):
-    preamble = r"\usepackage{times} "
-    if family == "serif":
-        return {
-            "text.usetex": True,
-            "font.family": "serif",
-            "text.latex.preamble": preamble,
-        }
-    preamble += (
-        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
-    )
-    return {
-        "text.usetex": True,
-        "font.family": "sans-serif",
-        "text.latex.preamble": preamble,
-    }
-
-
-def _tex_computer_modern(*, family):
-    if family == "serif":
-        return {
-            "text.usetex": True,
-            "font.family": "serif",
-            "text.latex.preamble": "",
-        }
-    preamble = (
-        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
-    )
-    return {
-        "text.usetex": True,
-        "font.family": "sans-serif",
-        "text.latex.preamble": preamble,
-    }
+    return _times(family=family)
 
 
 def beamer_moml():
@@ -200,4 +136,94 @@ def beamer_moml_dark_bg():
         "font.weight": "light",
         "axes.labelweight": "light",
         "axes.titleweight": "light",
+    }
+
+
+# Helper functions below
+
+
+def _times(*, family="serif"):
+    """Times font.
+
+    Used, e.g., for ICML 2022.
+    """
+    # todo: remove default family.
+    return {
+        "text.usetex": False,
+        "font.serif": ["Times"],
+        "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
+        "mathtext.rm": "Times",
+        "mathtext.it": "Times:italic",
+        "mathtext.bf": "Times:bold",
+        "font.family": family,
+    }
+
+
+# def _times_new_roman(*, family="serif"):
+#     """Default fonts for Neurips."""
+#     return {
+#         "text.usetex": False,
+#         "font.serif": ["Times New Roman"],
+#         "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
+#         "mathtext.rm": "Times New Roman",
+#         "mathtext.it": "Times New Roman:italic",
+#         "mathtext.bf": "Times New Roman:bold",
+#         "font.family": family,
+#     }
+
+
+def _times_tex_via_pkg_ptm(*, family):
+    """Times font, implemented in Latex via the ptm-package.
+
+    Default fonts for Neurips.
+    """
+    preamble = r"\renewcommand{\rmdefault}{ptm}\renewcommand{\sfdefault}{phv}"
+    if family == "serif":
+        return {
+            "text.usetex": True,
+            "font.family": "serif",
+            "text.latex.preamble": preamble,
+        }
+    preamble += (
+        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
+    )
+    return {
+        "text.usetex": True,
+        "font.family": "sans-serif",
+        "text.latex.preamble": preamble,
+    }
+
+
+def _times_tex_via_pkg_times(*, family):
+    preamble = r"\usepackage{times} "
+    if family == "serif":
+        return {
+            "text.usetex": True,
+            "font.family": "serif",
+            "text.latex.preamble": preamble,
+        }
+    preamble += (
+        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
+    )
+    return {
+        "text.usetex": True,
+        "font.family": "sans-serif",
+        "text.latex.preamble": preamble,
+    }
+
+
+def _computer_modern_tex(*, family):
+    if family == "serif":
+        return {
+            "text.usetex": True,
+            "font.family": "serif",
+            "text.latex.preamble": "",
+        }
+    preamble = (
+        r"\renewcommand{\familydefault}{\sfdefault} \usepackage{sansmath} \sansmath"
+    )
+    return {
+        "text.usetex": True,
+        "font.family": "sans-serif",
+        "text.latex.preamble": preamble,
     }

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -159,19 +159,6 @@ def _times(*, family="serif"):
     }
 
 
-# def _times_new_roman(*, family="serif"):
-#     """Default fonts for Neurips."""
-#     return {
-#         "text.usetex": False,
-#         "font.serif": ["Times New Roman"],
-#         "mathtext.fontset": "stix",  # free ptmx replacement, for ICML and NeurIPS
-#         "mathtext.rm": "Times New Roman",
-#         "mathtext.it": "Times New Roman:italic",
-#         "mathtext.bf": "Times New Roman:bold",
-#         "font.family": family,
-#     }
-
-
 def _times_tex_via_pkg_ptm(*, family):
     """Times font, implemented in Latex via the ptm-package.
 


### PR DESCRIPTION
This PR tries to make the font file more transparent. 

- The functions have been reordered so the helper functions, e.g. font families are at the bottom, and paper font functions are at the top
- Font selection functions have been renamed to make clear which fonts they're defining 
- Neurips and ICML paper use times (instead of Times New Roman), so this has been corrected