### PR TITLE
Style-file for ICML2024

### DIFF
--- a/tests/test_rc_params_cases/case_bundles.py
+++ b/tests/test_rc_params_cases/case_bundles.py
@@ -22,6 +22,14 @@ def case_bundles_icml2022(column, usetex):
 
 
 @pytest_cases.parametrize(column=["full", "half"])
+@pytest_cases.parametrize(usetex=[True, False])
+def case_bundles_icml2024(column, usetex):
+    return bundles.icml2024(
+        nrows=2, ncols=2, family="serif", column=column, usetex=usetex
+    )
+
+
+@pytest_cases.parametrize(column=["full", "half"])
 def case_bundles_aistats2022(column):
     return bundles.aistats2022(column=column, nrows=2, ncols=2, family="serif")
 

--- a/tests/test_rc_params_cases/case_figsizes.py
+++ b/tests/test_rc_params_cases/case_figsizes.py
@@ -12,6 +12,14 @@ def case_figsizes_icml2022_half():
     return figsizes.icml2022_half(nrows=2, ncols=3, height_to_width_ratio=1.0)
 
 
+def case_figsizes_icml2024_full():
+    return figsizes.icml2024_full(nrows=2, ncols=3, height_to_width_ratio=1.0)
+
+
+def case_figsizes_icml2024_half():
+    return figsizes.icml2024_half(nrows=2, ncols=3, height_to_width_ratio=1.0)
+
+
 def case_figsizes_aistats2022_full():
     return figsizes.aistats2022_full(nrows=2, ncols=3, height_to_width_ratio=1.0)
 

--- a/tests/test_rc_params_cases/case_fonts.py
+++ b/tests/test_rc_params_cases/case_fonts.py
@@ -20,6 +20,22 @@ def case_fonts_icml2022_tex_custom():
     return fonts.icml2022_tex(family="serif")
 
 
+def case_fonts_icml2024_default():
+    return fonts.icml2024()
+
+
+def case_fonts_icml2024_custom():
+    return fonts.icml2024(family="serif")
+
+
+def case_fonts_icml2024_tex_default():
+    return fonts.icml2024_tex()
+
+
+def case_fonts_icml2024_tex_custom():
+    return fonts.icml2024_tex(family="serif")
+
+
 def case_fonts_neurips2021_default():
     return fonts.neurips2021()
 

--- a/tests/test_rc_params_cases/case_fontsizes.py
+++ b/tests/test_rc_params_cases/case_fontsizes.py
@@ -11,6 +11,10 @@ def case_fontsizes_icml2022():
     return fontsizes.icml2022()
 
 
+def case_fontsizes_icml2024():
+    return fontsizes.icml2024()
+
+
 def case_fontsizes_neurips2021():
     return fontsizes.neurips2021()
 

--- a/tueplots/bundles.py
+++ b/tueplots/bundles.py
@@ -32,6 +32,20 @@ def icml2022(*, column="half", nrows=1, ncols=1, usetex=True, family="serif"):
     return {**font_config, **size, **fontsize_config}
 
 
+def icml2024(*, column="half", nrows=1, ncols=1, usetex=True, family="serif"):
+    """ICML 2024 bundle."""
+    if column == "half":
+        size = figsizes.icml2024_half(nrows=nrows, ncols=ncols)
+    elif column == "full":
+        size = figsizes.icml2024_full(nrows=nrows, ncols=ncols)
+    if usetex is True:
+        font_config = fonts.icml2024_tex(family=family)
+    elif usetex is False:
+        font_config = fonts.icml2024(family=family)
+    fontsize_config = fontsizes.icml2024()
+    return {**font_config, **size, **fontsize_config}
+
+
 def aistats2022(*, column="half", nrows=1, ncols=1, family="serif"):
     """AISTATS 2022 bundle."""
     if column == "half":

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -25,6 +25,16 @@ def icml2022_full(**kwargs):
     return _icml_and_aistats_common_full(**kwargs)
 
 
+def icml2024_half(**kwargs):
+    """Double-column (half-width) figures for ICML 2024."""
+    return _icml_and_aistats_common_half(**kwargs)
+
+
+def icml2024_full(**kwargs):
+    """Single-column (full-width) figures for ICML 2024."""
+    return _icml_and_aistats_common_full(**kwargs)
+
+
 def aistats2022_half(**kwargs):
     """Double-column (half-width) figures for AISTATS 2022."""
     return _icml_and_aistats_common_half(**kwargs)

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -78,6 +78,11 @@ def icml2022_tex(*, family="serif"):
     return _times_tex_via_pkg_times(family=family)
 
 
+def icml2024_tex(*, family="serif"):
+    """Fonts for ICML 2024. LaTeX version."""
+    return _times_tex_via_pkg_times(family=family)
+
+
 def jmlr2001_tex(*, family="serif"):
     """Fonts for JMLR. LaTeX version."""
     return _computer_modern_tex(family=family)
@@ -110,6 +115,11 @@ def aaai2024_tex(*, family="serif"):
 
 def icml2022(*, family="serif"):
     """Fonts for ICML 2022."""
+    return _times(family=family)
+
+
+def icml2024(*, family="serif"):
+    """Fonts for ICML 2024."""
     return _times(family=family)
 
 

--- a/tueplots/fontsizes.py
+++ b/tueplots/fontsizes.py
@@ -11,6 +11,16 @@ def icml2022(*, default_smaller=1):
     return _from_base(base=9 - default_smaller)
 
 
+def icml2024(*, default_smaller=1):
+    r"""Font size for ICML 2024.
+
+    Source: https://media.icml.cc/Conferences/ICML2024/Styles/example_paper.pdf
+    """
+    # ICML text size is 10, but captions are in size 9.
+    # Therefore, we use base 9 instead of 10.
+    return _from_base(base=9 - default_smaller)
+
+
 def cvpr2024(*, default_smaller=1):
     """Font size for CVPR 2024."""
     # CVPR text size is 10, but captions are in size 9.


### PR DESCRIPTION
This PR adds the bundles, figsizes, fonts, and fontsizes for ICML 2024.

To the best of my knowledge, there is no difference to the ICML2022 style.
See https://media.icml.cc/Conferences/ICML2024/Styles/example_paper.pdf for reference.