### PR TITLE
Adapt "docs" CI action for Python 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build the HTML docs
       run: |
+        pip install setuptools
         pip install tox
         sudo apt-get install pandoc
         tox -e docs


### PR DESCRIPTION
As referenced in PR #133.

venvs created with Python 3.12 no longer include `setuptools`, so we need to install it manually.

Let's see if this fixes the CI :)