### PR TITLE
Style-file for ECCV2024

### DIFF
--- a/tests/test_rc_params_cases/case_bundles.py
+++ b/tests/test_rc_params_cases/case_bundles.py
@@ -74,6 +74,10 @@ def case_bundles_uai2023(column):
     return bundles.uai2023(column=column, nrows=2, ncols=2, family="serif")
 
 
+def case_bundles_eccv2024():
+    return bundles.eccv2024(nrows=2, ncols=2, family="serif")
+
+
 def case_bundles_jmlr2001():
     return bundles.jmlr2001(nrows=2, ncols=2, family="serif")
 

--- a/tests/test_rc_params_cases/case_figsizes.py
+++ b/tests/test_rc_params_cases/case_figsizes.py
@@ -87,6 +87,10 @@ def case_figsizes_uai2023_full():
     return figsizes.uai2023_full(nrows=2, ncols=3, height_to_width_ratio=1.0)
 
 
+def case_figsizes_eccv2024():
+    return figsizes.eccv2024(nrows=2, ncols=3, height_to_width_ratio=1.0)
+
+
 def case_figsizes_jmlr2001():
     return figsizes.jmlr2001(nrows=2, ncols=3, height_to_width_ratio=1.0)
 

--- a/tests/test_rc_params_cases/case_fonts.py
+++ b/tests/test_rc_params_cases/case_fonts.py
@@ -123,6 +123,14 @@ def case_fonts_uai2023_tex_custom():
     return fonts.uai2023_tex(family="serif")
 
 
+def case_fonts_eccv2024_tex_default():
+    return fonts.eccv2024_tex()
+
+
+def case_fonts_eccv2024_tex_custom():
+    return fonts.eccv2024_tex(family="serif")
+
+
 def case_fonts_jmlr2001_tex_default():
     return fonts.jmlr2001_tex()
 

--- a/tests/test_rc_params_cases/case_fontsizes.py
+++ b/tests/test_rc_params_cases/case_fontsizes.py
@@ -51,6 +51,10 @@ def case_fontsizes_uai2023():
     return fontsizes.uai2023()
 
 
+def case_fontsizes_eccv2024():
+    return fontsizes.eccv2024()
+
+
 def case_fontsizes_jmlr2001():
     return fontsizes.jmlr2001()
 

--- a/tueplots/bundles.py
+++ b/tueplots/bundles.py
@@ -93,6 +93,14 @@ def uai2023(*, column="half", nrows=1, ncols=1, family="serif"):
     return {**font_config, **size, **fontsize_config}
 
 
+def eccv2024(*, rel_width=1.0, nrows=1, ncols=1, family="serif"):
+    """ECCV 2024 bundle."""
+    size = figsizes.eccv2024(rel_width=rel_width, nrows=nrows, ncols=ncols)
+    font_config = fonts.eccv2024_tex(family=family)
+    fontsize_config = fontsizes.eccv2024()
+    return {**font_config, **size, **fontsize_config}
+
+
 def jmlr2001(*, rel_width=1.0, nrows=1, ncols=1, family="serif"):
     """JMLR 2001 bundle."""
     size = figsizes.jmlr2001(rel_width=rel_width, nrows=nrows, ncols=ncols)

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -362,6 +362,8 @@ def jmlr2001(
     """JMLR figure size.
 
     Source: https://www.jmlr.org/format/format.html
+
+    The present format is for US letter format.
     """
 
     figsize = _from_base_in(

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -319,6 +319,36 @@ def cvpr2024_full(
 # Single-column formats
 
 
+def eccv2024(
+    *,
+    rel_width=1.0,
+    nrows=1,
+    ncols=2,
+    constrained_layout=True,
+    tight_layout=False,
+    height_to_width_ratio=_GOLDEN_RATIO,
+    pad_inches=_PAD_INCHES,
+):
+    """ECCV figure size.
+
+    Source: https://eccv2024.ecva.net/Conferences/2024/SubmissionPolicies
+    """
+
+    figsize = _from_base_in(
+        base_width_in=4.8,  # corresponds to 122mm in ECCV template
+        rel_width=rel_width,
+        height_to_width_ratio=height_to_width_ratio,
+        nrows=nrows,
+        ncols=ncols,
+    )
+    return _figsize_to_output_dict(
+        figsize=figsize,
+        constrained_layout=constrained_layout,
+        tight_layout=tight_layout,
+        pad_inches=pad_inches,
+    )
+
+
 def jmlr2001(
     *,
     rel_width=1.0,
@@ -332,8 +362,6 @@ def jmlr2001(
     """JMLR figure size.
 
     Source: https://www.jmlr.org/format/format.html
-
-    The present format is for US letter format.
     """
 
     figsize = _from_base_in(

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -83,6 +83,11 @@ def icml2024_tex(*, family="serif"):
     return _times_tex_via_pkg_times(family=family)
 
 
+def eccv2024_tex(*, family="serif"):
+    """Fonts for ECCV 2024. LaTeX version."""
+    return _computer_modern_tex(family=family)
+
+
 def jmlr2001_tex(*, family="serif"):
     """Fonts for JMLR. LaTeX version."""
     return _computer_modern_tex(family=family)

--- a/tueplots/fontsizes.py
+++ b/tueplots/fontsizes.py
@@ -73,6 +73,13 @@ def uai2023(*, default_smaller=1):
     return _from_base(base=10 - default_smaller)
 
 
+def eccv2024(*, default_smaller=1):
+    """Font size for ECCV 2024."""
+    # ECCV text size is 10, but captions are in size 9.
+    # Therefore, we use base 9 instead of 10.
+    return _from_base(base=9 - default_smaller)
+
+
 def jmlr2001(*, default_smaller=1):
     """Font size for JMLR 2021."""
     return _from_base(base=10.95 - default_smaller)


### PR DESCRIPTION
This PR adds the bundles, figsizes, fonts, and fontsizes for [ECCV 2024](https://eccv2024.ecva.net/Conferences/2024/SubmissionPolicies).

The ECCV template is single-column, so I mainly adapted the styles for JMLR2001. I checked the LaTeX template and found:
- font size: 9pt for captions
- font: Computer Modern
- text width: 122mm (4.8in)

