### PR TITLE
Style file for neurips2024

### DIFF
--- a/tests/test_rc_params_cases/case_bundles.py
+++ b/tests/test_rc_params_cases/case_bundles.py
@@ -55,6 +55,11 @@ def case_bundles_neurips2023(usetex):
 
 
 @pytest_cases.parametrize(usetex=[True, False])
+def case_bundles_neurips2024(usetex):
+    return bundles.neurips2024(usetex=usetex, nrows=2, ncols=2, family="serif")
+
+
+@pytest_cases.parametrize(usetex=[True, False])
 def case_bundles_iclr2023(usetex):
     return bundles.iclr2023(usetex=usetex, nrows=2, ncols=2, family="serif")
 

--- a/tests/test_rc_params_cases/case_figsizes.py
+++ b/tests/test_rc_params_cases/case_figsizes.py
@@ -63,6 +63,10 @@ def case_figsizes_neurips2023():
     return figsizes.neurips2023(nrows=2, ncols=3, height_to_width_ratio=1.0)
 
 
+def case_figsizes_neurips2024():
+    return figsizes.neurips2024(nrows=2, ncols=3, height_to_width_ratio=1.0)
+
+
 def case_figsizes_iclr2023():
     return figsizes.iclr2023(nrows=2, ncols=3, height_to_width_ratio=1.0)
 

--- a/tests/test_rc_params_cases/case_fonts.py
+++ b/tests/test_rc_params_cases/case_fonts.py
@@ -83,6 +83,22 @@ def case_fonts_neurips2023_tex_custom():
     return fonts.neurips2023_tex(family="serif")
 
 
+def case_fonts_neurips2024_default():
+    return fonts.neurips2024()
+
+
+def case_fonts_neurips2024_custom():
+    return fonts.neurips2024(family="serif")
+
+
+def case_fonts_neurips2024_tex_default():
+    return fonts.neurips2024_tex()
+
+
+def case_fonts_neurips2024_tex_custom():
+    return fonts.neurips2024_tex(family="serif")
+
+
 def case_fonts_iclr2023_tex_default():
     return fonts.iclr2023_tex()
 

--- a/tests/test_rc_params_cases/case_fontsizes.py
+++ b/tests/test_rc_params_cases/case_fontsizes.py
@@ -27,6 +27,10 @@ def case_fontsizes_neurips2023():
     return fontsizes.neurips2023()
 
 
+def case_fontsizes_neurips2024():
+    return fontsizes.neurips2024()
+
+
 def case_fontsizes_iclr2023():
     return fontsizes.iclr2023()
 

--- a/tueplots/bundles.py
+++ b/tueplots/bundles.py
@@ -150,6 +150,17 @@ def neurips2023(*, usetex=True, rel_width=1.0, nrows=1, ncols=1, family="serif")
     return {**font_config, **size, **fontsize_config}
 
 
+def neurips2024(*, usetex=True, rel_width=1.0, nrows=1, ncols=1, family="serif"):
+    """Neurips 2024 bundle."""
+    if usetex is True:
+        font_config = fonts.neurips2024_tex(family=family)
+    elif usetex is False:
+        font_config = fonts.neurips2024(family=family)
+    size = figsizes.neurips2024(rel_width=rel_width, nrows=nrows, ncols=ncols)
+    fontsize_config = fontsizes.neurips2024()
+    return {**font_config, **size, **fontsize_config}
+
+
 def iclr2023(*, usetex=True, rel_width=1.0, nrows=1, ncols=1, family="serif"):
     """ICLR 2023 bundle."""
     if usetex is True:

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -476,6 +476,29 @@ def neurips2023(
     )
 
 
+def neurips2024(
+    *,
+    rel_width=1.0,
+    nrows=1,
+    ncols=2,
+    constrained_layout=True,
+    tight_layout=False,
+    height_to_width_ratio=_GOLDEN_RATIO,
+    pad_inches=_PAD_INCHES,
+):
+    """Neurips 2024 figure size.
+    Source: https://nips.cc/Conferences/2024/CallForPapers"""
+    return _neurips_and_iclr_common(
+        rel_width=rel_width,
+        nrows=nrows,
+        ncols=ncols,
+        constrained_layout=constrained_layout,
+        tight_layout=tight_layout,
+        height_to_width_ratio=height_to_width_ratio,
+        pad_inches=pad_inches,
+    )
+
+
 def iclr2023(
     *,
     rel_width=1.0,

--- a/tueplots/fonts.py
+++ b/tueplots/fonts.py
@@ -43,6 +43,20 @@ def neurips2023_tex(*, family="serif"):
     return _times_tex_via_pkg_ptm(family=family)
 
 
+def neurips2024(*, family="serif"):
+    """Fonts for Neurips 2024."""
+    # NeurIPS' style-files states that it uses Times New Roman
+    # font, but includes the 'ptm' package, which implements
+    # the 'Times' font.
+    # Therefore, refer to 'Times' instead of 'Times New Roman'
+    return _times(family=family)
+
+
+def neurips2024_tex(*, family="serif"):
+    """Fonts for Neurips 2024. LaTeX version."""
+    return _times_tex_via_pkg_ptm(family=family)
+
+
 def iclr2023_tex(*, family="serif"):
     """Fonts for ICLR 2023. LaTeX version."""
     return _times_tex_via_pkg_times(family=family)

--- a/tueplots/fontsizes.py
+++ b/tueplots/fontsizes.py
@@ -43,6 +43,11 @@ def neurips2023(*, default_smaller=1):
     return _from_base(base=10 - default_smaller)
 
 
+def neurips2024(*, default_smaller=1):
+    """Font size for Neurips 2024."""
+    return _from_base(base=10 - default_smaller)
+
+
 def iclr2023(*, default_smaller=1):
     """Font size for ICLR 2023."""
     return _from_base(base=10 - default_smaller)


### PR DESCRIPTION
Description: This PR adds the bundles, figsizes, fonts, and fontsizes for Neurips 2024.

All values are the same as in previous years; see [https://neurips.cc/Conferences/2024/CallForPapers](https://neurips.cc/Conferences/2024/CallForPapers) for reference.