### PR TITLE
Replace m2r2 with myst_parser

### DIFF
--- a/docs/requirements-sphinx-build.txt
+++ b/docs/requirements-sphinx-build.txt
@@ -1,5 +1,5 @@
 sphinx
 nbsphinx
-m2r2
+myst-parser
 jupyter
 sphinx-book-theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.napoleon",
     "nbsphinx",
-    "m2r2",
+    "myst_parser",
 ]
 
 source_suffix = [".rst", ".md"]


### PR DESCRIPTION
As per title.

The reason is fixing the doc-related CI (see the current failures in #145).

Using myst_parser is also recommended by the [sphinx docs](https://www.sphinx-doc.org/en/master/usage/markdown.html).