### PR TITLE
Deprecate fontsizes.beamer_moml in favour of fontsizes.beamer

### DIFF
--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,10 @@
+"""Test that deprecations are announced appropriately."""
+
+import pytest
+
+from tueplots import fontsizes
+
+
+def test_fontsize_beamer_function_renamed():
+    with pytest.deprecated_call(match="renamed"):
+        _ = fontsizes.beamer_moml()

--- a/tests/test_rc_params_cases/case_fontsizes.py
+++ b/tests/test_rc_params_cases/case_fontsizes.py
@@ -67,5 +67,5 @@ def case_fontsizes_jmlr2001():
     return fontsizes.jmlr2001()
 
 
-def case_fontsizes_beamer_moml():
-    return fontsizes.beamer_moml()
+def case_fontsizes_beamer():
+    return fontsizes.beamer()

--- a/tueplots/bundles.py
+++ b/tueplots/bundles.py
@@ -260,7 +260,7 @@ def beamer_moml(
     axes_config_grid = axes.grid()
     axes_config_color = axes.color(base=rgb.tue_dark)
     cycler_config = cycler.cycler(color=palettes.tue_plot)
-    fontsize_config = fontsizes.beamer_moml()
+    fontsize_config = fontsizes.beamer()
     return {
         **size,
         **font_config,
@@ -280,7 +280,7 @@ def beamer_moml_dark_bg(*, rel_width=1.0, rel_height=0.8):
     axes_config_grid = axes.grid()
     axes_config_color = axes.color(face=rgb.tue_dark, base="w")
     cycler_config = cycler.cycler(color=palettes.tue_plot_dark_bg)
-    fontsize_config = fontsizes.beamer_moml()
+    fontsize_config = fontsizes.beamer()
     return {
         **size,
         **font_config,

--- a/tueplots/fontsizes.py
+++ b/tueplots/fontsizes.py
@@ -103,7 +103,10 @@ def tmlr2023(*, default_smaller=1):
 
 
 def beamer_moml(**kwargs):
-    """Font size for a beamer slide in aspectratio 16:9 with 10pt font."""
+    """Font size for a beamer slide in aspectratio 16:9 with 10pt font.
+
+    Deprecated in v0.0.16. Use 'fontsizes.beamer' instead.
+    """
     msg = "'fontsizes.beamer_moml' has been renamed to 'fontsizes.beamer' in v0.0.16."
     msg += " The old API will be removed any time after January 1st, 2025."
     warnings.warn(msg, DeprecationWarning)

--- a/tueplots/fontsizes.py
+++ b/tueplots/fontsizes.py
@@ -1,5 +1,7 @@
 """Fontsize settings."""
 
+import warnings
+
 
 def icml2022(*, default_smaller=1):
     r"""Font size for ICML 2022.
@@ -100,8 +102,16 @@ def tmlr2023(*, default_smaller=1):
     return _from_base(base=10 - default_smaller)
 
 
-def beamer_moml(*, default_smaller=1):
+def beamer_moml(**kwargs):
     """Font size for a beamer slide in aspectratio 16:9 with 10pt font."""
+    msg = "'fontsizes.beamer_moml' has been renamed to 'fontsizes.beamer' in v0.0.16."
+    msg += " The old API will be removed any time after January 1st, 2025."
+    warnings.warn(msg, DeprecationWarning)
+    return beamer(**kwargs)
+
+
+def beamer(*, default_smaller=1):
+    """Font size for a beamer slide (in aspectratio 16:9 with 10pt font)."""
     return _from_base(base=10 - default_smaller)
 
 


### PR DESCRIPTION
Why? Because there is nothing 'moml' about the fontsize. 