### PR TITLE
Delete 'savefig.bbox' = 'tight' from default figure-size configuration

### DIFF
--- a/docs/source/getting_started/application_icml2022.md
+++ b/docs/source/getting_started/application_icml2022.md
@@ -9,9 +9,9 @@ is `plt.rcParams.update(bundles.icml2022())`:
 >>> import matplotlib.pyplot as plt
 >>> from tueplots import bundles
 >>> bundles.icml2022()
-{'text.usetex': True, 'font.family': 'serif', 'text.latex.preamble': '\\usepackage{times} ', 'figure.figsize': (3.25, 2.0086104634371584), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.bbox': 'tight', 'savefig.pad_inches': 0.015, 'font.size': 8, 'axes.labelsize': 8, 'legend.fontsize': 6, 'xtick.labelsize': 6, 'ytick.labelsize': 6, 'axes.titlesize': 8}
+{'text.usetex': True, 'font.family': 'serif', 'text.latex.preamble': '\\usepackage{times} ', 'figure.figsize': (3.25, 2.0086104634371584), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.pad_inches': 0.015, 'font.size': 8, 'axes.labelsize': 8, 'legend.fontsize': 6, 'xtick.labelsize': 6, 'ytick.labelsize': 6, 'axes.titlesize': 8}
 >>> bundles.icml2022(family="sans-serif", usetex=False, column="full", nrows=2)
-{'text.usetex': False, 'font.serif': ['Times'], 'mathtext.fontset': 'stix', 'mathtext.rm': 'Times', 'mathtext.it': 'Times:italic', 'mathtext.bf': 'Times:bold', 'font.family': 'sans-serif', 'figure.figsize': (6.75, 8.343458848123582), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.bbox': 'tight', 'savefig.pad_inches': 0.015, 'font.size': 8, 'axes.labelsize': 8, 'legend.fontsize': 6, 'xtick.labelsize': 6, 'ytick.labelsize': 6, 'axes.titlesize': 8}
+{'text.usetex': False, 'font.serif': ['Times'], 'mathtext.fontset': 'stix', 'mathtext.rm': 'Times', 'mathtext.it': 'Times:italic', 'mathtext.bf': 'Times:bold', 'font.family': 'sans-serif', 'figure.figsize': (6.75, 8.343458848123582), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.pad_inches': 0.015, 'font.size': 8, 'axes.labelsize': 8, 'legend.fontsize': 6, 'xtick.labelsize': 6, 'ytick.labelsize': 6, 'axes.titlesize': 8}
 >>>
 >>> # Plug any of those into either the rcParams or into an rc_context:
 >>> plt.rcParams.update(bundles.icml2022())
@@ -27,9 +27,9 @@ If you don't want a pre-packaged solution, at least fix your figure- and font-si
 ```python
 >>> from tueplots import figsizes, fontsizes, fonts
 >>> figsizes.icml2022_full()
-{'figure.figsize': (6.75, 2.0858647120308955), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.bbox': 'tight', 'savefig.pad_inches': 0.015}
+{'figure.figsize': (6.75, 2.0858647120308955), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.pad_inches': 0.015}
 >>> figsizes.icml2022_half(nrows=2, constrained_layout=True, tight_layout=False)
-{'figure.figsize': (3.25, 4.017220926874317), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.bbox': 'tight', 'savefig.pad_inches': 0.015}
+{'figure.figsize': (3.25, 4.017220926874317), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.pad_inches': 0.015}
 >>> fontsizes.icml2022()
 {'font.size': 8, 'axes.labelsize': 8, 'legend.fontsize': 6, 'xtick.labelsize': 6, 'ytick.labelsize': 6, 'axes.titlesize': 8}
 >>> fonts.icml2022()

--- a/docs/source/getting_started/troubleshooting.md
+++ b/docs/source/getting_started/troubleshooting.md
@@ -1,9 +1,9 @@
 # FAQ: Frequently asked questions
 
-## My version of matplotlib cannot find font XYZ?!
+## My version of matplotlib cannot find font XYZ
 
-Some fonts that `tueplot` provides (e.g., `Times` or `Roboto`) must be installed on your machine before matplotlib can find them.
-This means that you need to find a `.ttf` file online (e.g., the `Roboto` family is available at Google fonts: [link-to-roboto](https://fonts.google.com/specimen/Roboto),
+Some fonts that Tueplots uses (e.g., `Times` or `Roboto`) must be installed on your machine before matplotlib can find them.
+This installation means that you need to find a `.ttf` file online (e.g., the `Roboto` family is available at Google fonts: [link-to-roboto](https://fonts.google.com/specimen/Roboto),
 download it, and install it. For Ubuntu, this means opening the file (with your font manager) and clicking `install`.
 There are probably many other ways to do this.
 Once the font is installed, delete your matplotlib cache (usually: `rm ~/.cache/matplotlib -rf`) and restart your notebook (not just the kernel).
@@ -12,7 +12,7 @@ See also [this question on Stack Overflow](https://stackoverflow.com/questions/4
 On a related note: if you want to use the Latex version of the fonts/bundles, your system must include the required tex packages.
 See [this Stack Overflow discussion](https://stackoverflow.com/questions/55746749/latex-equations-do-not-render-in-google-colaboratory-when-using-matplotlib)
 for information.
-You may encounter this problem when using Tueplots in combination with a Google Colab notebook.
+You may encounter this problem when using Tueplots with a Google Colab notebook.
 
 
 
@@ -24,23 +24,31 @@ If someone knows why, please let us know. :)
 ## I am still getting 'overfull hbox' errors in my latex code
 
 Even though the figure sizes delivered by Tueplots match the figure sizes in style files exactly, sometimes, figures can be a few points wider than what latex allows.
-Visually, this does not make any difference,
-but it might lead to an 'overfull hbox' raised by, e.g., 'pdflatex'.
-This is not Tueplots' fault but likely due to the optimisation that matplotlib carries out
-as part of constrained_layout=True or tight_layout=True.
-Refer to the <a href=https://matplotlib.org/stable/tutorials/intermediate/constrainedlayout_guide.html>constrained layout documentation</a>
-for more info.
+Visually, this does not make any difference, but it might lead to an 'overfull hbox' raised by, e.g., 'pdflatex'.
+This overfull hbox is not Tueplots' fault but more due to how matplotlib draws figures:
+- The figure dimensions are optimised differently, depending on whether a user selects constrained_layout=True or tight_layout=True (or neither).
+  Refer to the <a href=https://matplotlib.org/stable/tutorials/intermediate/constrainedlayout_guide.html>constrained layout documentation</a> for more info.
+
+- Sometimes, rounding errors in the division by dpi or an ignored linewidth may lead to marginally inaccurate figure sizes.
+  See [Issue #129](https://github.com/pnkraemer/tueplots/issues/129) for context and more explanation.
+
 
 **Solution:**
-If you really cannot live with this warning, there are the following possible solutions:
-* Instead of `\includegraphics(<plot>)`, use `\includegraphics[width=\textwidth](<plot>)`. This fixes the final few pixels, and the visual difference is non-existent.
+If you want to avoid this warning by any means, here are some solutions:
+* Instead of `\includegraphics(<plot>)`, use `\includegraphics[width=\textwidth](<plot>)`. This argument fixes the final few pixels; the visual difference is non-existent.
 * Set the `rel_width` in the figsizes to, e.g., `rel_width=0.97` and use `\includegraphics(<plot>)` as usual.
+* Set the `savefig.bbox` argument to `tight`, as in:
+```python
+with mpl.rc_context({'savefig.bbox': 'standard'}):
+    plt.savefig("figure.pdf")
+```
+and again, see [Issue #129](https://github.com/pnkraemer/tueplots/issues/129) for more info.
 
 
 ## My submission template requires Type 1 fonts
 
 Type 1 fonts are a tricky requirement; for example, because
-<a href=https://helpx.adobe.com/fonts/kb/postscript-type-1-fonts-end-of-support.html> Adobe will disable support for authoring with Type 1 fonts in January 2023 </a>.
+<a href=https://helpx.adobe.com/fonts/kb/postscript-type-1-fonts-end-of-support.html> Adobe will turn off support for authoring with Type 1 fonts in January 2023 </a>.
 Matplotlib cannot do Type 1 fonts but uses Type 3 as a default.
 There is also no way of making matplotlib use Type 1 fonts.
 The only options are Type 3 and Type 42 (/TrueType) fonts.

--- a/docs/source/getting_started/usage_example.md
+++ b/docs/source/getting_started/usage_example.md
@@ -20,7 +20,7 @@ within one module, the functions have a unified interface (wherever possible)
 >>>
 >>> # The full output:
 >>> figsizes.icml2022_full(nrows=4)
-{'figure.figsize': (6.75, 8.343458848123582), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.bbox': 'tight', 'savefig.pad_inches': 0.015}
+{'figure.figsize': (6.75, 8.343458848123582), 'figure.constrained_layout.use': True, 'figure.autolayout': False, 'savefig.pad_inches': 0.015}
 
 ```
 

--- a/tueplots/figsizes.py
+++ b/tueplots/figsizes.py
@@ -685,6 +685,5 @@ def _figsize_to_output_dict(
         "figure.figsize": figsize,
         "figure.constrained_layout.use": constrained_layout,
         "figure.autolayout": tight_layout,
-        "savefig.bbox": "tight",
         "savefig.pad_inches": pad_inches,
     }


### PR DESCRIPTION
Resolves #129.  

This change isn't backward compatible because the media size of saved matplotlib figures changes after this PR. For the reasoning, see #129.